### PR TITLE
Add npm scripts and health-check server skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.log

--- a/TASKS.md
+++ b/TASKS.md
@@ -3,7 +3,7 @@
 > Each task should result in runnable commands and/or visible UI changes. Keep PRs small.
 
 ## Phase 0 — Repo hygiene
-- [ ] Add package scripts (`bootstrap`, `dev`, `start`, `test`, `e2e:smoke`, `lint`, `fmt`, `typecheck`)
+- [x] Add package scripts (`bootstrap`, `dev`, `start`, `test`, `e2e:smoke`, `lint`, `fmt`, `typecheck`) — tests: `npm test`, `npm run e2e:smoke`
   - **AC:** `npm run dev` starts an HTTP server with `/health`; `npm test` runs a dummy test.
 - [ ] Add lint/format config and ensure they run.
   - **AC:** `npm run lint` and `npm run fmt` succeed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,17 @@
+{
+  "name": "weaveos",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "weaveos",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {},
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "weaveos",
+  "version": "0.1.0",
+  "description": "WeaveOS API and minimal runtime",
+  "type": "commonjs",
+  "scripts": {
+    "bootstrap": "npm install",
+    "build": "tsc --project tsconfig.build.json",
+    "dev": "npm run build && node dist/server.js",
+    "start": "node dist/server.js",
+    "test": "npm run build && node --test tests/**/*.test.js",
+    "e2e:smoke": "npm run build && node --test tests/e2e",
+    "lint": "eslint .",
+    "fmt": "prettier --write .",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,35 @@
+import { createServer, IncomingMessage, Server, ServerResponse } from 'node:http';
+
+export interface AppOptions {
+  logger?: boolean;
+}
+
+const sendJson = (response: ServerResponse, statusCode: number, payload: unknown): void => {
+  response.statusCode = statusCode;
+  response.setHeader('content-type', 'application/json');
+  response.end(JSON.stringify(payload));
+};
+
+const handleRequest = (request: IncomingMessage, response: ServerResponse): void => {
+  const method = (request.method ?? 'GET').toUpperCase();
+  const url = request.url ?? '/';
+
+  if (method === 'GET' && url === '/health') {
+    sendJson(response, 200, { status: 'ok' });
+    return;
+  }
+
+  sendJson(response, 404, { status: 'not_found' });
+};
+
+export const createAppServer = (_options: AppOptions = {}): Server => {
+  const server = createServer((request, response) => {
+    try {
+      handleRequest(request, response);
+    } catch (error) {
+      sendJson(response, 500, { status: 'error' });
+    }
+  });
+
+  return server;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,18 @@
+import { createAppServer } from './app';
+
+const DEFAULT_PORT = 3000;
+const DEFAULT_HOST = '0.0.0.0';
+
+const port = Number.parseInt(process.env.PORT ?? `${DEFAULT_PORT}`, 10);
+const host = process.env.HOST ?? DEFAULT_HOST;
+
+const server = createAppServer();
+
+server.listen({ port, host }, () => {
+  console.log({ event: 'server.start', entity: 'server', status: 'listening', meta: { port, host } });
+});
+
+server.on('error', (error) => {
+  console.error({ event: 'server.start', entity: 'server', status: 'error', meta: { error } });
+  process.exit(1);
+});

--- a/tests/e2e/smoke.test.js
+++ b/tests/e2e/smoke.test.js
@@ -1,0 +1,7 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// Placeholder to keep the e2e command green while the full harness is developed.
+test('placeholder e2e assertion', () => {
+  assert.equal(true, true);
+});

--- a/tests/integration/health.test.js
+++ b/tests/integration/health.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createAppServer } = require('../../dist/app.js');
+
+const listen = (server, options) =>
+  new Promise((resolve, reject) => {
+    server.listen(options, () => resolve(server));
+    server.on('error', reject);
+  });
+
+const close = (server) =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+test('GET /health returns ok', async () => {
+  const server = createAppServer();
+  await listen(server, { port: 0, host: '127.0.0.1' });
+  const address = server.address();
+  assert.ok(address, 'server should have an address after listen');
+
+  const url = `http://${address.address}:${address.port}/health`;
+  const response = await fetch(url);
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.deepEqual(payload, { status: 'ok' });
+
+  await close(server);
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "typeRoots": ["./types"]
+  },
+  "include": ["src", "types"],
+  "ts-node": {
+    "swc": true
+  }
+}

--- a/types/global/index.d.ts
+++ b/types/global/index.d.ts
@@ -1,0 +1,13 @@
+interface ProcessEnv {
+  [key: string]: string | undefined;
+}
+
+declare const process: {
+  env: ProcessEnv;
+  exit(code?: number): never;
+};
+
+declare const console: {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};

--- a/types/node-http/index.d.ts
+++ b/types/node-http/index.d.ts
@@ -1,0 +1,33 @@
+declare module 'node:http' {
+  export interface IncomingMessage {
+    method?: string | null;
+    url?: string | null;
+  }
+
+  export interface ServerResponse {
+    statusCode: number;
+    setHeader(name: string, value: string): void;
+    end(payload?: string): void;
+  }
+
+  export interface ListenOptions {
+    port: number;
+    host: string;
+  }
+
+  export interface ServerAddress {
+    port: number;
+    address: string;
+  }
+
+  export interface Server {
+    listen(options: ListenOptions, callback?: () => void): Server;
+    close(callback?: (error?: Error) => void): void;
+    address(): ServerAddress | null;
+    on(event: 'error', listener: (error: Error) => void): Server;
+  }
+
+  export type RequestListener = (request: IncomingMessage, response: ServerResponse) => void;
+
+  export function createServer(listener: RequestListener): Server;
+}


### PR DESCRIPTION
## Summary
- add npm scripts and configuration to bootstrap, build, and type-check the project
- implement a minimal HTTP server with a /health route plus supporting type declarations
- create placeholder integration/e2e tests and mark the initial TASKS item complete

## Testing
- npm test
- npm run e2e:smoke
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc19b6a518832995ac35574178bac9