### PR TITLE
Implement basic rituals endpoints

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -13,7 +13,8 @@
 
 - [ ] Create `api/openapi.yaml` with MVP endpoints listed in SPECS.md.
   - **AC:** File exists; paths compile with an OpenAPI linter.
-- [ ] Implement **/rituals**: `POST`, `GET`, `GET/{id}`
+- [x] Implement **/rituals**: `POST`, `GET`, `GET/{id}` — tests: `npm test`
+  - Completed: Added in-memory ritual store with create/list/get handlers and integration coverage.
   - **AC:** Can create and list rituals with `ritual_key`, `name`, `instant_runs`.
 - [ ] Implement **/rituals/{id}/runs**: `POST`
   - **AC:** Returns a run with `run_key` defaulting to ISO date.

--- a/tests/integration/rituals.test.js
+++ b/tests/integration/rituals.test.js
@@ -1,0 +1,102 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createAppServer } = require('../../dist/app.js');
+
+const listen = (server, options) =>
+  new Promise((resolve, reject) => {
+    server.listen(options, () => resolve(server));
+    server.on('error', reject);
+  });
+
+const close = (server) =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+const isIsoDateString = (value) => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed);
+};
+
+test('ritual lifecycle supports create, list, get, and run creation', async () => {
+  const server = createAppServer();
+  await listen(server, { port: 0, host: '127.0.0.1' });
+  const address = server.address();
+  assert.ok(address, 'server should have an address after listen');
+
+  const baseUrl = `http://${address.address}:${address.port}`;
+
+  const ritualRequestBody = {
+    ritual_key: 'trash-day',
+    name: 'Trash day pickup',
+    instant_runs: true,
+    inputs: [
+      {
+        type: 'external_link',
+        value: 'https://city.local/trash',
+        label: 'City schedule',
+      },
+    ],
+  };
+
+  const createResponse = await fetch(`${baseUrl}/rituals`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(ritualRequestBody),
+  });
+
+  assert.equal(createResponse.status, 201);
+  const createPayload = await createResponse.json();
+  assert.deepEqual(createPayload.ritual.ritual_key, ritualRequestBody.ritual_key);
+  assert.deepEqual(createPayload.ritual.name, ritualRequestBody.name);
+  assert.equal(createPayload.ritual.instant_runs, ritualRequestBody.instant_runs);
+  assert.equal(createPayload.ritual.inputs.length, 1);
+  assert.ok(isIsoDateString(createPayload.ritual.created_at));
+  assert.ok(isIsoDateString(createPayload.ritual.updated_at));
+  assert.deepEqual(createPayload.ritual.runs, []);
+
+  const listResponse = await fetch(`${baseUrl}/rituals`);
+  assert.equal(listResponse.status, 200);
+  const listPayload = await listResponse.json();
+  assert.equal(listPayload.rituals.length, 1);
+  assert.equal(listPayload.rituals[0].ritual_key, ritualRequestBody.ritual_key);
+
+  const getResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}`);
+  assert.equal(getResponse.status, 200);
+  const getPayload = await getResponse.json();
+  assert.equal(getPayload.ritual.ritual_key, ritualRequestBody.ritual_key);
+  assert.deepEqual(getPayload.ritual.runs, []);
+
+  const runResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}/runs`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+
+  assert.equal(runResponse.status, 201);
+  const runPayload = await runResponse.json();
+  assert.equal(runPayload.run.ritual_key, ritualRequestBody.ritual_key);
+  assert.equal(runPayload.run.status, 'planned');
+  assert.ok(isIsoDateString(runPayload.run.run_key));
+  assert.ok(isIsoDateString(runPayload.run.created_at));
+  assert.ok(isIsoDateString(runPayload.run.updated_at));
+
+  const ritualAfterRunResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}`);
+  assert.equal(ritualAfterRunResponse.status, 200);
+  const ritualAfterRunPayload = await ritualAfterRunResponse.json();
+  assert.equal(ritualAfterRunPayload.ritual.runs.length, 1);
+  assert.equal(ritualAfterRunPayload.ritual.runs[0].status, 'planned');
+  assert.equal(ritualAfterRunPayload.ritual.runs[0].run_key, runPayload.run.run_key);
+
+  await close(server);
+});


### PR DESCRIPTION
## Summary
- add an in-memory store to serve POST/GET ritual endpoints and create runs
- validate ritual payloads, return structured responses, and update the task checklist
- cover the ritual lifecycle with an integration test exercising creation, listing, retrieval, and run creation

## Testing
- npm test --prefix WeaveOS
- npm run e2e:smoke --prefix WeaveOS

------
https://chatgpt.com/codex/tasks/task_e_68dc21029cd0832984040a8cabb59989