### PR TITLE
Add instant rituals run auto-completion

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -17,12 +17,14 @@
 - [x] Implement **/rituals**: `POST`, `GET`, `GET/{id}` — tests: `npm test`
   - Completed: Added in-memory ritual store with create/list/get handlers and integration coverage.
   - **AC:** Can create and list rituals with `ritual_key`, `name`, `instant_runs`.
-- [ ] Implement **/rituals/{id}/runs**: `POST`
+- [x] Implement **/rituals/{id}/runs**: `POST`
+  - Completed: Added run creation handler with ISO `run_key` default and coverage via integration tests. — tests: `npm test`, `npm run e2e:smoke`
   - **AC:** Returns a run with `run_key` defaulting to ISO date.
 
 ## Phase 2 — Lightweight rituals & instant runs
 
-- [ ] Add `instant_runs` semantics
+- [x] Add `instant_runs` semantics
+  - Completed: Instant rituals now auto-complete runs while scheduled rituals remain planned until progressed. — tests: `npm test`, `npm run e2e:smoke`
   - **AC:** If `instant_runs=true`, creating a run auto-starts and auto-completes unless blocked.
 - [ ] Add _pasted link_ support as a run/ritual **input** (Unresolved Target)
   - **AC:** Rituals accept a list of `external_link` inputs; runs inherit them.

--- a/src/app.ts
+++ b/src/app.ts
@@ -266,16 +266,21 @@ const handleCreateRun = async (
     return;
   }
 
-  const timestamp = new Date().toISOString();
+  const createdAt = new Date();
   const run: RunRecord = {
     run_key: runKey,
     ritual_key: ritual.ritual_key,
     status: 'planned',
-    created_at: timestamp,
-    updated_at: timestamp,
+    created_at: createdAt.toISOString(),
+    updated_at: createdAt.toISOString(),
   };
 
-  ritual.updated_at = timestamp;
+  if (ritual.instant_runs) {
+    run.status = 'complete';
+    run.updated_at = new Date().toISOString();
+  }
+
+  ritual.updated_at = run.updated_at;
   ritual.runs.push(run);
   state.runs.set(runKey, run);
 

--- a/tests/integration/rituals.test.js
+++ b/tests/integration/rituals.test.js
@@ -28,75 +28,129 @@ const isIsoDateString = (value) => {
   return Number.isFinite(parsed);
 };
 
-test('ritual lifecycle supports create, list, get, and run creation', async () => {
+const startServer = async () => {
   const server = createAppServer();
   await listen(server, { port: 0, host: '127.0.0.1' });
   const address = server.address();
-  assert.ok(address, 'server should have an address after listen');
+  assert.ok(address && typeof address === 'object', 'server should have an address after listen');
 
   const baseUrl = `http://${address.address}:${address.port}`;
+  return { server, baseUrl };
+};
 
-  const ritualRequestBody = {
-    ritual_key: 'trash-day',
-    name: 'Trash day pickup',
-    instant_runs: true,
-    inputs: [
-      {
-        type: 'external_link',
-        value: 'https://city.local/trash',
-        label: 'City schedule',
-      },
-    ],
-  };
+test('instant rituals auto-complete runs immediately', async () => {
+  const { server, baseUrl } = await startServer();
 
-  const createResponse = await fetch(`${baseUrl}/rituals`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(ritualRequestBody),
-  });
+  try {
+    const ritualRequestBody = {
+      ritual_key: 'trash-day',
+      name: 'Trash day pickup',
+      instant_runs: true,
+      inputs: [
+        {
+          type: 'external_link',
+          value: 'https://city.local/trash',
+          label: 'City schedule',
+        },
+      ],
+    };
 
-  assert.equal(createResponse.status, 201);
-  const createPayload = await createResponse.json();
-  assert.deepEqual(createPayload.ritual.ritual_key, ritualRequestBody.ritual_key);
-  assert.deepEqual(createPayload.ritual.name, ritualRequestBody.name);
-  assert.equal(createPayload.ritual.instant_runs, ritualRequestBody.instant_runs);
-  assert.equal(createPayload.ritual.inputs.length, 1);
-  assert.ok(isIsoDateString(createPayload.ritual.created_at));
-  assert.ok(isIsoDateString(createPayload.ritual.updated_at));
-  assert.deepEqual(createPayload.ritual.runs, []);
+    const createResponse = await fetch(`${baseUrl}/rituals`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(ritualRequestBody),
+    });
 
-  const listResponse = await fetch(`${baseUrl}/rituals`);
-  assert.equal(listResponse.status, 200);
-  const listPayload = await listResponse.json();
-  assert.equal(listPayload.rituals.length, 1);
-  assert.equal(listPayload.rituals[0].ritual_key, ritualRequestBody.ritual_key);
+    assert.equal(createResponse.status, 201);
+    const createPayload = await createResponse.json();
+    assert.equal(createPayload.ritual.ritual_key, ritualRequestBody.ritual_key);
+    assert.equal(createPayload.ritual.name, ritualRequestBody.name);
+    assert.equal(createPayload.ritual.instant_runs, ritualRequestBody.instant_runs);
+    assert.equal(createPayload.ritual.inputs.length, 1);
+    assert.ok(isIsoDateString(createPayload.ritual.created_at));
+    assert.ok(isIsoDateString(createPayload.ritual.updated_at));
+    assert.deepEqual(createPayload.ritual.runs, []);
 
-  const getResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}`);
-  assert.equal(getResponse.status, 200);
-  const getPayload = await getResponse.json();
-  assert.equal(getPayload.ritual.ritual_key, ritualRequestBody.ritual_key);
-  assert.deepEqual(getPayload.ritual.runs, []);
+    const listResponse = await fetch(`${baseUrl}/rituals`);
+    assert.equal(listResponse.status, 200);
+    const listPayload = await listResponse.json();
+    assert.equal(listPayload.rituals.length, 1);
+    assert.equal(listPayload.rituals[0].ritual_key, ritualRequestBody.ritual_key);
 
-  const runResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}/runs`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({}),
-  });
+    const getResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}`);
+    assert.equal(getResponse.status, 200);
+    const getPayload = await getResponse.json();
+    assert.equal(getPayload.ritual.ritual_key, ritualRequestBody.ritual_key);
+    assert.deepEqual(getPayload.ritual.runs, []);
 
-  assert.equal(runResponse.status, 201);
-  const runPayload = await runResponse.json();
-  assert.equal(runPayload.run.ritual_key, ritualRequestBody.ritual_key);
-  assert.equal(runPayload.run.status, 'planned');
-  assert.ok(isIsoDateString(runPayload.run.run_key));
-  assert.ok(isIsoDateString(runPayload.run.created_at));
-  assert.ok(isIsoDateString(runPayload.run.updated_at));
+    const runResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
 
-  const ritualAfterRunResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}`);
-  assert.equal(ritualAfterRunResponse.status, 200);
-  const ritualAfterRunPayload = await ritualAfterRunResponse.json();
-  assert.equal(ritualAfterRunPayload.ritual.runs.length, 1);
-  assert.equal(ritualAfterRunPayload.ritual.runs[0].status, 'planned');
-  assert.equal(ritualAfterRunPayload.ritual.runs[0].run_key, runPayload.run.run_key);
+    assert.equal(runResponse.status, 201);
+    const runPayload = await runResponse.json();
+    assert.equal(runPayload.run.ritual_key, ritualRequestBody.ritual_key);
+    assert.equal(runPayload.run.status, 'complete');
+    assert.ok(isIsoDateString(runPayload.run.run_key));
+    assert.ok(isIsoDateString(runPayload.run.created_at));
+    assert.ok(isIsoDateString(runPayload.run.updated_at));
+    assert.ok(
+      Date.parse(runPayload.run.updated_at) >= Date.parse(runPayload.run.created_at),
+      'completed runs should not have an updated_at before created_at',
+    );
 
-  await close(server);
+    const ritualAfterRunResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}`);
+    assert.equal(ritualAfterRunResponse.status, 200);
+    const ritualAfterRunPayload = await ritualAfterRunResponse.json();
+    assert.equal(ritualAfterRunPayload.ritual.runs.length, 1);
+    assert.equal(ritualAfterRunPayload.ritual.runs[0].status, 'complete');
+    assert.equal(ritualAfterRunPayload.ritual.runs[0].run_key, runPayload.run.run_key);
+  } finally {
+    await close(server);
+  }
+});
+
+test('non-instant rituals create planned runs', async () => {
+  const { server, baseUrl } = await startServer();
+
+  try {
+    const ritualRequestBody = {
+      ritual_key: 'saturday-groceries',
+      name: 'Saturday grocery run',
+      instant_runs: false,
+      inputs: [],
+    };
+
+    const createResponse = await fetch(`${baseUrl}/rituals`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(ritualRequestBody),
+    });
+
+    assert.equal(createResponse.status, 201);
+
+    const runResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    });
+
+    assert.equal(runResponse.status, 201);
+    const runPayload = await runResponse.json();
+    assert.equal(runPayload.run.status, 'planned');
+    assert.equal(runPayload.run.ritual_key, ritualRequestBody.ritual_key);
+    assert.ok(isIsoDateString(runPayload.run.run_key));
+    assert.ok(isIsoDateString(runPayload.run.created_at));
+    assert.ok(isIsoDateString(runPayload.run.updated_at));
+    assert.equal(runPayload.run.created_at, runPayload.run.updated_at);
+
+    const ritualAfterRunResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}`);
+    assert.equal(ritualAfterRunResponse.status, 200);
+    const ritualAfterRunPayload = await ritualAfterRunResponse.json();
+    assert.equal(ritualAfterRunPayload.ritual.runs.length, 1);
+    assert.equal(ritualAfterRunPayload.ritual.runs[0].status, 'planned');
+  } finally {
+    await close(server);
+  }
 });


### PR DESCRIPTION
## Summary
- update run creation to immediately complete runs for instant rituals while keeping other runs planned
- expand integration coverage to verify instant and non-instant run status handling and ensure clean server teardown
- check off the corresponding tasks documenting the change and associated tests

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dc2fbe2968832982feb2c385ed42a7