### PR TITLE
Add ritual inputs to run responses

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -26,8 +26,8 @@
 - [x] Add `instant_runs` semantics
   - Completed: Instant rituals now auto-complete runs while scheduled rituals remain planned until progressed. — tests: `npm test`, `npm run e2e:smoke`
   - **AC:** If `instant_runs=true`, creating a run auto-starts and auto-completes unless blocked.
-- [ ] Add _pasted link_ support as a run/ritual **input** (Unresolved Target)
-  - **AC:** Rituals accept a list of `external_link` inputs; runs inherit them.
+- [x] Add _pasted link_ support as a run/ritual **input** (Unresolved Target)
+  - Completed: Runs now inherit ritual `external_link` inputs and expose them via the API. — tests: `npm test`, `npm run e2e:smoke`
 
 ## Phase 3 — Attention Items (human-in-the-loop)
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -244,6 +244,7 @@ components:
         - status
         - created_at
         - updated_at
+        - inputs
       properties:
         run_key:
           type: string
@@ -262,6 +263,11 @@ components:
         updated_at:
           type: string
           format: date-time
+        inputs:
+          type: array
+          description: Inputs available to this run, inherited from the parent ritual.
+          items:
+            $ref: '#/components/schemas/RitualInput'
     Ritual:
       type: object
       required:

--- a/src/app.ts
+++ b/src/app.ts
@@ -62,6 +62,7 @@ interface RunRecord {
   created_at: string;
   updated_at: string;
   activity_log: ActivityLogEntry[];
+  inputs: RitualInput[];
 }
 
 interface RitualRecord {
@@ -132,6 +133,7 @@ const normalizeRitualForResponse = (ritual: RitualRecord): RitualRecord => ({
     created_at: run.created_at,
     updated_at: run.updated_at,
     activity_log: run.activity_log,
+    inputs: run.inputs.map((input) => ({ ...input })),
   })),
 });
 
@@ -321,6 +323,7 @@ const handleCreateRun = async (
     created_at: createdAt.toISOString(),
     updated_at: createdAt.toISOString(),
     activity_log: [],
+    inputs: ritual.inputs.map((input) => ({ ...input })),
   };
 
   if (ritual.instant_runs) {
@@ -332,7 +335,12 @@ const handleCreateRun = async (
   ritual.runs.push(run);
   state.runs.set(runKey, run);
 
-  sendJson(response, 201, { run });
+  sendJson(response, 201, {
+    run: {
+      ...run,
+      inputs: run.inputs.map((input) => ({ ...input })),
+    },
+  });
 };
 
 const createAttentionId = (): string => `attn_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;

--- a/tests/integration/rituals.test.js
+++ b/tests/integration/rituals.test.js
@@ -96,6 +96,7 @@ test('instant rituals auto-complete runs immediately', async () => {
     assert.ok(isIsoDateString(runPayload.run.run_key));
     assert.ok(isIsoDateString(runPayload.run.created_at));
     assert.ok(isIsoDateString(runPayload.run.updated_at));
+    assert.deepEqual(runPayload.run.inputs, ritualRequestBody.inputs);
     assert.ok(
       Date.parse(runPayload.run.updated_at) >= Date.parse(runPayload.run.created_at),
       'completed runs should not have an updated_at before created_at',
@@ -107,6 +108,7 @@ test('instant rituals auto-complete runs immediately', async () => {
     assert.equal(ritualAfterRunPayload.ritual.runs.length, 1);
     assert.equal(ritualAfterRunPayload.ritual.runs[0].status, 'complete');
     assert.equal(ritualAfterRunPayload.ritual.runs[0].run_key, runPayload.run.run_key);
+    assert.deepEqual(ritualAfterRunPayload.ritual.runs[0].inputs, ritualRequestBody.inputs);
   } finally {
     await close(server);
   }
@@ -144,12 +146,14 @@ test('non-instant rituals create planned runs', async () => {
     assert.ok(isIsoDateString(runPayload.run.created_at));
     assert.ok(isIsoDateString(runPayload.run.updated_at));
     assert.equal(runPayload.run.created_at, runPayload.run.updated_at);
+    assert.deepEqual(runPayload.run.inputs, []);
 
     const ritualAfterRunResponse = await fetch(`${baseUrl}/rituals/${ritualRequestBody.ritual_key}`);
     assert.equal(ritualAfterRunResponse.status, 200);
     const ritualAfterRunPayload = await ritualAfterRunResponse.json();
     assert.equal(ritualAfterRunPayload.ritual.runs.length, 1);
     assert.equal(ritualAfterRunPayload.ritual.runs[0].status, 'planned');
+    assert.deepEqual(ritualAfterRunPayload.ritual.runs[0].inputs, []);
   } finally {
     await close(server);
   }


### PR DESCRIPTION
## Summary
- ensure runs inherit ritual external_link inputs and return them in API responses
- document run inputs in the OpenAPI schema and cover the behavior with integration tests
- mark the pasted link support task as complete in TASKS.md

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dc3c0c98788329bcf3d76a8ac8956d