### PR TITLE
Document attention endpoints

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -31,9 +31,9 @@
 
 ## Phase 3 — Attention Items (human-in-the-loop)
 
-- [ ] Implement **POST /attention** and **GET /runs/{id}/attention**
+- [x] Implement **POST /attention** and **GET /runs/{id}/attention** — tests: `npm test`, `npm run e2e:smoke`; note: Added in-memory attention store and listing ([tests/integration/attention.test.js](tests/integration/attention.test.js))
   - **AC:** Prep/start logic can create an attention item (mock); list shows it.
-- [ ] Add `on_attention_resolved` event (mock implementation)
+- [x] Add `on_attention_resolved` event (mock implementation) — tests: `npm test`, `npm run e2e:smoke`; note: Resolving attention logs run activity ([tests/integration/attention.test.js](tests/integration/attention.test.js))
   - **AC:** Resolving an item triggers a log entry on the run.
 
 ## Phase 4 — Automations (mock)

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -154,23 +154,82 @@ paths:
   /attention:
     post:
       summary: Create attention item
-      description: Placeholder for future implementation.
+      description: Create an in-memory attention item for a run.
       tags: [Attention]
       operationId: createAttention
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAttentionRequest'
       responses:
-        '501':
-          description: Not implemented
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateAttentionResponse'
+        '400':
+          description: Invalid payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Run not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /runs/{run_id}/attention:
     get:
       summary: List run attention items
-      description: Placeholder for future implementation.
+      description: List attention items associated with a run.
       tags: [Attention]
       operationId: listRunAttention
       parameters:
         - $ref: '#/components/parameters/RunId'
       responses:
-        '501':
-          description: Not implemented
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListRunAttentionResponse'
+        '404':
+          description: Run not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /attention/{attention_id}/resolve:
+    post:
+      summary: Resolve attention item
+      description: Resolve an attention item and log the resolution on the parent run.
+      tags: [Attention]
+      operationId: resolveAttention
+      parameters:
+        - $ref: '#/components/parameters/AttentionId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResolveAttentionResponse'
+        '404':
+          description: Attention item or run not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Attention item already resolved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /automations:
     post:
       summary: Register automation
@@ -198,6 +257,13 @@ components:
       schema:
         type: string
       description: Unique key for the ritual.
+    AttentionId:
+      in: path
+      name: attention_id
+      required: true
+      schema:
+        type: string
+      description: Unique identifier for the attention item.
     RunId:
       in: path
       name: run_id
@@ -245,6 +311,7 @@ components:
         - created_at
         - updated_at
         - inputs
+        - activity_log
       properties:
         run_key:
           type: string
@@ -268,6 +335,11 @@ components:
           description: Inputs available to this run, inherited from the parent ritual.
           items:
             $ref: '#/components/schemas/RitualInput'
+        activity_log:
+          type: array
+          description: Timeline of notable run events.
+          items:
+            $ref: '#/components/schemas/ActivityLogEntry'
     Ritual:
       type: object
       required:
@@ -357,3 +429,85 @@ components:
       properties:
         run:
           $ref: '#/components/schemas/Run'
+    ActivityLogEntry:
+      type: object
+      required:
+        - timestamp
+        - event
+        - message
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        event:
+          type: string
+          description: Machine-readable event name.
+          example: on_attention_resolved
+        message:
+          type: string
+          description: Human readable summary of the event.
+        metadata:
+          type: object
+          nullable: true
+          additionalProperties: {}
+    AttentionItem:
+      type: object
+      required:
+        - attention_id
+        - run_key
+        - type
+        - message
+        - resolved
+        - created_at
+      properties:
+        attention_id:
+          type: string
+          example: attn_1716111967_abcd12345
+        run_key:
+          type: string
+        type:
+          type: string
+          enum: [auth_needed, missing_draft, decision_required, other]
+        message:
+          type: string
+        resolved:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        resolved_at:
+          type: string
+          format: date-time
+          nullable: true
+    CreateAttentionRequest:
+      type: object
+      required: [run_key, type, message]
+      additionalProperties: false
+      properties:
+        run_key:
+          type: string
+        type:
+          type: string
+          enum: [auth_needed, missing_draft, decision_required, other]
+        message:
+          type: string
+    CreateAttentionResponse:
+      type: object
+      required: [attention]
+      properties:
+        attention:
+          $ref: '#/components/schemas/AttentionItem'
+    ListRunAttentionResponse:
+      type: object
+      required: [attention_items]
+      properties:
+        attention_items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttentionItem'
+    ResolveAttentionResponse:
+      type: object
+      required: [attention]
+      properties:
+        attention:
+          $ref: '#/components/schemas/AttentionItem'


### PR DESCRIPTION
## Summary
- document the attention create/list/resolve endpoints in the OpenAPI spec and add supporting schemas
- include activity log details in the run schema for parity with the API responses
- update TASKS.md to mark the attention work complete with test references

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dc656231ec832986da17da2964fcbb