### PR TITLE
Add minimal home dashboard UI

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -47,7 +47,8 @@
 
 ## Phase 5 — Minimal UI (no build tools required)
 
-- [ ] **Home**: single-line ritual creator + Upcoming + Needs Attention
+- [x] **Home**: single-line ritual creator + Upcoming + Needs Attention
+  - Completed: Added static home dashboard with intent parser, ritual list, and attention feed backed by existing APIs. — tests: `npm test`, `npm run e2e:smoke`
   - **AC:** Can create a ritual by typing “Trash day Fridays 7am https://link”; ritual appears; link listed.
 - [ ] **Ritual page**: show cadence, instant badge, default inputs, “Create run now”
   - **AC:** Button creates a run; if instant, a toast shows “Run complete”.

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,241 @@
+(function () {
+  const form = document.getElementById('ritual-form');
+  const intentInput = document.getElementById('ritual-intent');
+  const instantCheckbox = document.getElementById('instant-runs');
+  const submitButton = form.querySelector('button[type="submit"]');
+  const feedback = document.getElementById('form-feedback');
+  const upcomingList = document.getElementById('upcoming-list');
+  const upcomingEmpty = document.getElementById('upcoming-empty');
+  const attentionList = document.getElementById('attention-list');
+  const attentionEmpty = document.getElementById('attention-empty');
+  const refreshButton = document.getElementById('refresh');
+
+  const setFeedback = (message, isError = false) => {
+    feedback.textContent = message;
+    feedback.classList.toggle('error', isError);
+  };
+
+  const slugify = (value) =>
+    value
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+  const parseIntent = (rawIntent) => {
+    const trimmed = rawIntent.trim();
+    const urlMatch = trimmed.match(/https?:\/\/\S+/);
+    const link = urlMatch ? urlMatch[0] : null;
+    const name = link ? trimmed.replace(link, '').trim() : trimmed;
+    const fallbackName = name.length > 0 ? name : 'Untitled ritual';
+    const slug = slugify(fallbackName) || 'ritual';
+    const uniqueSuffix = Date.now().toString(36);
+    const ritualKey = `${slug}-${uniqueSuffix}`;
+
+    return {
+      name: fallbackName,
+      link,
+      ritualKey,
+    };
+  };
+
+  const toggleSubmitting = (isSubmitting) => {
+    submitButton.disabled = isSubmitting;
+    refreshButton.disabled = isSubmitting;
+    intentInput.disabled = isSubmitting;
+    instantCheckbox.disabled = isSubmitting;
+  };
+
+  const fetchJson = async (input, init) => {
+    const response = await fetch(input, init);
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      const errorMessage = errorBody.error || response.statusText || 'Request failed';
+      throw new Error(errorMessage);
+    }
+    return response.json();
+  };
+
+  const renderRituals = (rituals) => {
+    upcomingList.innerHTML = '';
+    if (rituals.length === 0) {
+      upcomingEmpty.hidden = false;
+      return;
+    }
+
+    upcomingEmpty.hidden = true;
+
+    rituals
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .forEach((ritual) => {
+        const item = document.createElement('li');
+        item.className = 'ritual-item';
+
+        const header = document.createElement('header');
+        const nameEl = document.createElement('span');
+        nameEl.className = 'ritual-name';
+        nameEl.textContent = ritual.name;
+        header.appendChild(nameEl);
+
+        const badge = document.createElement('span');
+        badge.className = `badge ${ritual.instant_runs ? '' : 'inactive'}`.trim();
+        badge.textContent = ritual.instant_runs ? 'Instant run' : 'Scheduled';
+        header.appendChild(badge);
+
+        item.appendChild(header);
+
+        const keyMeta = document.createElement('p');
+        keyMeta.className = 'ritual-meta';
+        keyMeta.textContent = `Key: ${ritual.ritual_key}`;
+        item.appendChild(keyMeta);
+
+        if (ritual.inputs && ritual.inputs.length > 0) {
+          const inputsHeading = document.createElement('p');
+          inputsHeading.className = 'inputs-heading';
+          inputsHeading.textContent = 'Inputs';
+          item.appendChild(inputsHeading);
+
+          const inputList = document.createElement('ul');
+          inputList.className = 'inputs-list';
+
+          ritual.inputs.forEach((input) => {
+            const li = document.createElement('li');
+            if (input.type === 'external_link') {
+              const anchor = document.createElement('a');
+              anchor.href = input.value;
+              anchor.target = '_blank';
+              anchor.rel = 'noreferrer noopener';
+              anchor.textContent = input.label || input.value;
+              li.appendChild(anchor);
+            } else {
+              li.textContent = input.value;
+            }
+            inputList.appendChild(li);
+          });
+
+          item.appendChild(inputList);
+        }
+
+        upcomingList.appendChild(item);
+      });
+  };
+
+  const renderAttention = (items) => {
+    attentionList.innerHTML = '';
+    if (items.length === 0) {
+      attentionEmpty.hidden = false;
+      return;
+    }
+
+    attentionEmpty.hidden = true;
+
+    items.forEach((item) => {
+      const li = document.createElement('li');
+      li.className = 'attention-item';
+
+      const message = document.createElement('strong');
+      message.textContent = item.message;
+      li.appendChild(message);
+
+      const context = document.createElement('span');
+      context.textContent = `${item.type.replace(/_/g, ' ')} • Run ${item.run_key} • ${item.ritual_name}`;
+      li.appendChild(context);
+
+      attentionList.appendChild(li);
+    });
+  };
+
+  const loadAttentionItems = async (rituals) => {
+    const pending = [];
+
+    rituals.forEach((ritual) => {
+      ritual.runs.forEach((run) => {
+        pending.push(
+          fetch(`/runs/${encodeURIComponent(run.run_key)}/attention`)
+            .then((response) => (response.ok ? response.json() : null))
+            .then((data) => {
+              if (!data || !Array.isArray(data.attention_items)) {
+                return [];
+              }
+
+              return data.attention_items
+                .filter((item) => !item.resolved)
+                .map((item) => ({
+                  ...item,
+                  ritual_name: ritual.name,
+                }));
+            })
+            .catch(() => []),
+        );
+      });
+    });
+
+    const results = await Promise.all(pending);
+    const flattened = results.reduce((acc, list) => acc.concat(list), []);
+    renderAttention(flattened);
+  };
+
+  const loadDashboard = async () => {
+    try {
+      const data = await fetchJson('/rituals');
+      const rituals = Array.isArray(data.rituals) ? data.rituals : [];
+      renderRituals(rituals);
+      await loadAttentionItems(rituals);
+    } catch (error) {
+      setFeedback(error.message || 'Unable to load rituals', true);
+    }
+  };
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const rawIntent = intentInput.value;
+    if (!rawIntent.trim()) {
+      setFeedback('Please describe the ritual you want to create.', true);
+      return;
+    }
+
+    const { name, link, ritualKey } = parseIntent(rawIntent);
+    const payload = {
+      ritual_key: ritualKey,
+      name,
+      instant_runs: instantCheckbox.checked,
+      inputs: link
+        ? [
+            {
+              type: 'external_link',
+              value: link,
+              label: 'Reference link',
+            },
+          ]
+        : [],
+    };
+
+    toggleSubmitting(true);
+    setFeedback('Creating ritual…');
+
+    try {
+      await fetchJson('/rituals', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      setFeedback('Ritual created!');
+      intentInput.value = '';
+      await loadDashboard();
+    } catch (error) {
+      setFeedback(error.message || 'Unable to create ritual', true);
+    } finally {
+      toggleSubmitting(false);
+    }
+  });
+
+  refreshButton.addEventListener('click', () => {
+    setFeedback('');
+    loadDashboard();
+  });
+
+  loadDashboard();
+})();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ritual OS</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Ritual OS</h1>
+      <p class="app-subtitle">Lightweight rituals, instant runs, human-in-the-loop.</p>
+    </header>
+    <main class="layout">
+      <section class="card">
+        <h2>Create a ritual</h2>
+        <form id="ritual-form" class="ritual-form">
+          <label class="input-group" for="ritual-intent">
+            <span class="input-label">Intent</span>
+            <input
+              id="ritual-intent"
+              name="intent"
+              type="text"
+              placeholder="Trash day Fridays 7am https://city/trash"
+              autocomplete="off"
+              required
+            />
+          </label>
+          <label class="checkbox">
+            <input id="instant-runs" name="instant" type="checkbox" checked />
+            <span>Instant runs (auto-complete)</span>
+          </label>
+          <button type="submit">Create ritual</button>
+          <p id="form-feedback" class="form-feedback" role="status" aria-live="polite"></p>
+        </form>
+      </section>
+      <section class="card" aria-labelledby="upcoming-title">
+        <div class="card-header">
+          <h2 id="upcoming-title">Upcoming rituals</h2>
+          <button id="refresh" type="button" class="secondary">Refresh</button>
+        </div>
+        <ul id="upcoming-list" class="ritual-list" role="list"></ul>
+        <p id="upcoming-empty" class="empty-state" hidden>No rituals yet. Create one to get started.</p>
+      </section>
+      <section class="card" aria-labelledby="attention-title">
+        <h2 id="attention-title">Needs attention</h2>
+        <ul id="attention-list" class="attention-list" role="list"></ul>
+        <p id="attention-empty" class="empty-state" hidden>No attention items right now.</p>
+      </section>
+    </main>
+    <script src="/app.js" defer></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,292 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f5f5f5;
+  color: #1f2933;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f9fafb 0%, #eef2f7 100%);
+}
+
+.app-header {
+  padding: 2.5rem 1.5rem 1rem;
+  text-align: center;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+.app-subtitle {
+  margin: 0.5rem 0 0;
+  color: #4b5563;
+  font-size: 1rem;
+}
+
+.layout {
+  display: grid;
+  gap: 1.5rem;
+  padding: 0 1.5rem 3rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+@media (min-width: 960px) {
+  .layout {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .layout > .card:first-of-type {
+    grid-column: span 3;
+  }
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 16px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+  backdrop-filter: blur(12px);
+}
+
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.ritual-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.input-group {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.input-label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+input[type='text'] {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type='text']:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.2);
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #374151;
+}
+
+button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  background: #2563eb;
+  color: white;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.25);
+}
+
+button:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button.secondary {
+  background: #e5e7eb;
+  color: #111827;
+  padding: 0.5rem 1rem;
+}
+
+button.secondary:hover {
+  box-shadow: none;
+  transform: none;
+  background: #d1d5db;
+}
+
+.form-feedback {
+  min-height: 1.25rem;
+  margin: 0;
+  font-size: 0.95rem;
+  color: #2563eb;
+}
+
+.form-feedback.error {
+  color: #dc2626;
+}
+
+.ritual-list,
+.attention-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.ritual-item {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  background: white;
+}
+
+.ritual-item header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.ritual-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(16, 185, 129, 0.1);
+  color: #047857;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.badge.inactive {
+  background: rgba(251, 191, 36, 0.15);
+  color: #b45309;
+}
+
+.inputs-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.inputs-list li {
+  font-size: 0.9rem;
+}
+
+.inputs-list a {
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.inputs-list a:hover {
+  text-decoration: underline;
+}
+
+.attention-item {
+  border-radius: 12px;
+  border: 1px solid #fee2e2;
+  background: #fef2f2;
+  padding: 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.attention-item strong {
+  font-size: 1rem;
+}
+
+.empty-state {
+  margin-top: 0.5rem;
+  color: #6b7280;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background-color: #0f172a;
+    color: #f8fafc;
+  }
+
+  body {
+    background: radial-gradient(circle at top, #1e293b, #0f172a);
+  }
+
+  .card {
+    background: rgba(15, 23, 42, 0.8);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+  }
+
+  .input-label {
+    color: #e2e8f0;
+  }
+
+  input[type='text'] {
+    border-color: rgba(148, 163, 184, 0.4);
+    background: rgba(15, 23, 42, 0.7);
+    color: inherit;
+  }
+
+  .ritual-item {
+    background: rgba(15, 23, 42, 0.9);
+    border-color: rgba(148, 163, 184, 0.25);
+  }
+
+  .badge {
+    background: rgba(16, 185, 129, 0.2);
+    color: #34d399;
+  }
+
+  .badge.inactive {
+    background: rgba(251, 191, 36, 0.25);
+    color: #facc15;
+  }
+
+  .inputs-list a {
+    color: #93c5fd;
+  }
+
+  .attention-item {
+    background: rgba(185, 28, 28, 0.15);
+    border-color: rgba(248, 113, 113, 0.4);
+  }
+}

--- a/types/global/index.d.ts
+++ b/types/global/index.d.ts
@@ -11,3 +11,5 @@ declare const console: {
   log: (...args: unknown[]) => void;
   error: (...args: unknown[]) => void;
 };
+
+declare const __dirname: string;

--- a/types/node-fs/index.d.ts
+++ b/types/node-fs/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'node:fs' {
+  namespace promises {
+    type BinaryLike = { toString(encoding?: string): string };
+
+    function readFile(path: string, options?: { encoding?: string }): Promise<BinaryLike | string>;
+  }
+}

--- a/types/node-path/index.d.ts
+++ b/types/node-path/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'node:path' {
+  function join(...segments: string[]): string;
+  function resolve(...segments: string[]): string;
+  function extname(path: string): string;
+}


### PR DESCRIPTION
## Summary
- add a static Home dashboard with a single-line ritual creator, ritual list, and attention feed
- serve public assets from the Node server and stub required fs/path types for TypeScript
- update the task tracker to mark the Home experience complete

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dc6ea7c7a48329bfc140007b051493