### PR TITLE
Add ritual detail page with run creation flow

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -50,7 +50,8 @@
 - [x] **Home**: single-line ritual creator + Upcoming + Needs Attention
   - Completed: Added static home dashboard with intent parser, ritual list, and attention feed backed by existing APIs. — tests: `npm test`, `npm run e2e:smoke`
   - **AC:** Can create a ritual by typing “Trash day Fridays 7am https://link”; ritual appears; link listed.
-- [ ] **Ritual page**: show cadence, instant badge, default inputs, “Create run now”
+- [x] **Ritual page**: show cadence, instant badge, default inputs, “Create run now” — tests: `npm test`, `npm run e2e:smoke`
+  - Completed: Added dedicated ritual detail view with run kick-off flow and success toast for instant runs.
   - **AC:** Button creates a run; if instant, a toast shows “Run complete”.
 - [ ] **Run mini-hub**: show status, next triggers (mock), activity log, attention items
   - **AC:** Attention item created via API is visible and can be resolved (mock).

--- a/public/app.js
+++ b/public/app.js
@@ -167,8 +167,13 @@
     rituals
       .sort((a, b) => a.name.localeCompare(b.name))
       .forEach((ritual) => {
-        const item = document.createElement('li');
-        item.className = 'ritual-item';
+        const listItem = document.createElement('li');
+        const link = document.createElement('a');
+        link.className = 'ritual-link';
+        link.href = `/ritual.html?ritual=${encodeURIComponent(ritual.ritual_key)}`;
+
+        const card = document.createElement('div');
+        card.className = 'ritual-item';
 
         const header = document.createElement('div');
         header.className = 'ritual-header';
@@ -182,17 +187,17 @@
         badge.textContent = ritual.instant_runs ? 'Auto-completes' : 'Needs wrap-up';
         header.appendChild(badge);
 
-        item.appendChild(header);
+        card.appendChild(header);
 
         const behaviour = document.createElement('p');
         behaviour.className = 'ritual-behaviour';
         behaviour.textContent = describeRunBehaviour(ritual);
-        item.appendChild(behaviour);
+        card.appendChild(behaviour);
 
         const runMeta = document.createElement('p');
         runMeta.className = 'ritual-run-meta';
         runMeta.textContent = formatRunStatus(latestRun(ritual.runs));
-        item.appendChild(runMeta);
+        card.appendChild(runMeta);
 
         if (ritual.inputs && ritual.inputs.length > 0) {
           const inputList = document.createElement('ul');
@@ -213,10 +218,12 @@
             inputList.appendChild(li);
           });
 
-          item.appendChild(inputList);
+          card.appendChild(inputList);
         }
 
-        upcomingList.appendChild(item);
+        link.appendChild(card);
+        listItem.appendChild(link);
+        upcomingList.appendChild(listItem);
       });
   };
 

--- a/public/ritual.html
+++ b/public/ritual.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ritual • WeaveOS</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body class="detail-body">
+    <header class="page-header">
+      <nav class="page-nav">
+        <a class="back-link" href="/">← Back to dashboard</a>
+      </nav>
+      <div class="ritual-hero">
+        <div class="ritual-heading">
+          <p class="ritual-key" id="ritual-key">Loading ritual…</p>
+          <h1 id="ritual-name">Loading…</h1>
+        </div>
+        <div class="ritual-meta">
+          <span id="instant-badge" class="badge" hidden>Instant ritual</span>
+          <span id="manual-badge" class="badge inactive" hidden>Manual wrap-up</span>
+          <span id="cadence-chip" class="chip" hidden></span>
+        </div>
+      </div>
+      <p class="ritual-subtitle" id="ritual-subtitle">WeaveOS is fetching the latest run state.</p>
+    </header>
+    <main class="detail-layout">
+      <section class="card detail-card">
+        <div class="detail-card-header">
+          <h2>Kick off a run</h2>
+          <p id="run-behaviour" class="detail-card-support">Agents will stage the run for you.</p>
+        </div>
+        <button id="create-run" type="button">Create run now</button>
+      </section>
+      <section class="card detail-card">
+        <div class="detail-card-header">
+          <h2>Reference links</h2>
+          <p class="detail-card-support">These travel with every run by default.</p>
+        </div>
+        <ul id="inputs-list" class="inputs-list"></ul>
+        <p id="inputs-empty" class="empty-state">No saved links yet. Add one when creating the ritual intent.</p>
+      </section>
+      <section class="card detail-card">
+        <div class="detail-card-header">
+          <h2>Recent runs</h2>
+          <p class="detail-card-support">Latest five runs with status updates.</p>
+        </div>
+        <ul id="runs-list" class="runs-list" role="list"></ul>
+        <p id="runs-empty" class="empty-state">No runs yet. Kick one off to see it here.</p>
+      </section>
+    </main>
+    <p id="toast" class="toast" role="status" aria-live="polite" hidden></p>
+    <script src="/ritual.js" defer></script>
+  </body>
+</html>

--- a/public/ritual.js
+++ b/public/ritual.js
@@ -1,0 +1,315 @@
+(function () {
+  const params = new URLSearchParams(window.location.search);
+  const ritualKeyParam = params.get('ritual') || params.get('ritual_key') || params.get('id');
+
+  const nameEl = document.getElementById('ritual-name');
+  const keyEl = document.getElementById('ritual-key');
+  const subtitleEl = document.getElementById('ritual-subtitle');
+  const instantBadge = document.getElementById('instant-badge');
+  const manualBadge = document.getElementById('manual-badge');
+  const cadenceChip = document.getElementById('cadence-chip');
+  const runBehaviourEl = document.getElementById('run-behaviour');
+  const createRunButton = document.getElementById('create-run');
+  const inputsList = document.getElementById('inputs-list');
+  const inputsEmpty = document.getElementById('inputs-empty');
+  const runsList = document.getElementById('runs-list');
+  const runsEmpty = document.getElementById('runs-empty');
+  const toast = document.getElementById('toast');
+
+  const CAPTURE_KEYWORDS =
+    '\\b(?:every|daily|weekly|monthly|quarterly|weekdays?|weekends?|mondays?|tuesdays?|wednesdays?|thursdays?|fridays?|saturdays?|sundays?|today|tonight|tomorrow|morning|afternoon|evening|night)\\b';
+
+  const cadencePattern = new RegExp(`${CAPTURE_KEYWORDS}.*$`, 'i');
+
+  const setToast = (message, tone = 'info') => {
+    if (!toast) {
+      return;
+    }
+
+    toast.textContent = message;
+    toast.className = `toast ${tone}`.trim();
+    toast.hidden = message.length === 0;
+  };
+
+  const fetchJson = async (input, init) => {
+    const response = await fetch(input, init);
+    if (!response.ok) {
+      let errorMessage = response.statusText || 'Request failed';
+      try {
+        const body = await response.json();
+        if (body && typeof body.error === 'string') {
+          errorMessage = body.error.replace(/_/g, ' ');
+        }
+      } catch (error) {
+        // Ignore JSON parse errors and fall back to status text.
+      }
+      throw new Error(errorMessage);
+    }
+
+    return response.json();
+  };
+
+  const formatRelativeTime = (input) => {
+    if (!input) {
+      return 'just now';
+    }
+
+    const date = input instanceof Date ? input : new Date(input);
+    if (Number.isNaN(date.getTime())) {
+      return 'just now';
+    }
+
+    const deltaSeconds = Math.round((Date.now() - date.getTime()) / 1000);
+    const absSeconds = Math.abs(deltaSeconds);
+
+    const thresholds = [
+      { limit: 60, unit: 'second', value: deltaSeconds },
+      { limit: 3600, unit: 'minute', value: Math.round(deltaSeconds / 60) },
+      { limit: 86400, unit: 'hour', value: Math.round(deltaSeconds / 3600) },
+      { limit: 604800, unit: 'day', value: Math.round(deltaSeconds / 86400) },
+    ];
+
+    const match = thresholds.find((entry) => absSeconds < entry.limit);
+    if (match) {
+      const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+      return rtf.format(match.value, match.unit);
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+    }).format(date);
+  };
+
+  const formatAbsoluteTimestamp = (input) => {
+    const date = input instanceof Date ? input : new Date(input);
+    if (Number.isNaN(date.getTime())) {
+      return 'Unknown time';
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date);
+  };
+
+  const statusLabel = (status) => {
+    switch (status) {
+      case 'planned':
+        return 'Scheduled';
+      case 'in_progress':
+        return 'In progress';
+      case 'complete':
+        return 'Completed';
+      default:
+        return 'Active';
+    }
+  };
+
+  const extractNameAndCadence = (rawName) => {
+    if (typeof rawName !== 'string' || rawName.trim().length === 0) {
+      return { name: 'Untitled ritual', cadence: null };
+    }
+
+    const trimmed = rawName.trim();
+    const cadenceMatch = trimmed.match(cadencePattern);
+
+    if (!cadenceMatch || cadenceMatch.index === undefined) {
+      return { name: trimmed, cadence: null };
+    }
+
+    const cadence = cadenceMatch[0].trim();
+    const name = trimmed.slice(0, cadenceMatch.index).trim();
+
+    return {
+      name: name.length > 0 ? name : trimmed,
+      cadence,
+    };
+  };
+
+  const renderInputs = (inputs) => {
+    inputsList.innerHTML = '';
+    if (!Array.isArray(inputs) || inputs.length === 0) {
+      inputsEmpty.hidden = false;
+      return;
+    }
+
+    inputsEmpty.hidden = true;
+
+    inputs.forEach((input) => {
+      const li = document.createElement('li');
+      if (input.type === 'external_link') {
+        const anchor = document.createElement('a');
+        anchor.href = input.value;
+        anchor.target = '_blank';
+        anchor.rel = 'noreferrer noopener';
+        anchor.textContent = input.label || input.value;
+        li.appendChild(anchor);
+      } else {
+        li.textContent = input.value;
+      }
+      inputsList.appendChild(li);
+    });
+  };
+
+  const renderRuns = (runs = []) => {
+    runsList.innerHTML = '';
+    if (!Array.isArray(runs) || runs.length === 0) {
+      runsEmpty.hidden = false;
+      return;
+    }
+
+    runsEmpty.hidden = true;
+
+    const sorted = [...runs].sort((a, b) => {
+      const aTime = new Date(a.updated_at || a.created_at || 0).getTime();
+      const bTime = new Date(b.updated_at || b.created_at || 0).getTime();
+      return bTime - aTime;
+    });
+
+    sorted.slice(0, 5).forEach((run) => {
+      const li = document.createElement('li');
+      li.className = 'run-item';
+
+      const header = document.createElement('div');
+      header.className = 'run-header';
+
+      const key = document.createElement('span');
+      key.className = 'run-key';
+      key.textContent = run.run_key;
+      header.appendChild(key);
+
+      const badge = document.createElement('span');
+      badge.className = `status-chip status-${run.status}`;
+      badge.textContent = statusLabel(run.status);
+      header.appendChild(badge);
+
+      li.appendChild(header);
+
+      const meta = document.createElement('p');
+      meta.className = 'run-meta';
+      meta.textContent = `${formatAbsoluteTimestamp(run.updated_at || run.created_at)} • ${formatRelativeTime(
+        run.updated_at || run.created_at,
+      )}`;
+      li.appendChild(meta);
+
+      if (Array.isArray(run.activity_log) && run.activity_log.length > 0) {
+        const latestLog = run.activity_log[run.activity_log.length - 1];
+        if (latestLog && latestLog.message) {
+          const activity = document.createElement('p');
+          activity.className = 'run-activity';
+          activity.textContent = latestLog.message;
+          li.appendChild(activity);
+        }
+      }
+
+      runsList.appendChild(li);
+    });
+  };
+
+  const latestRun = (runs = []) =>
+    runs.reduce((current, candidate) => {
+      if (!candidate) {
+        return current;
+      }
+
+      if (!current) {
+        return candidate;
+      }
+
+      const currentTime = new Date(current.updated_at || current.created_at || 0).getTime();
+      const candidateTime = new Date(candidate.updated_at || candidate.created_at || 0).getTime();
+      return candidateTime > currentTime ? candidate : current;
+    }, null);
+
+  const updateSubtitle = (ritual) => {
+    const run = latestRun(ritual.runs);
+    if (!run) {
+      subtitleEl.textContent = 'No runs yet — create one to get started.';
+      return;
+    }
+
+    subtitleEl.textContent = `${statusLabel(run.status)} • ${formatRelativeTime(run.updated_at || run.created_at)}`;
+  };
+
+  const renderRitual = (ritual) => {
+    const { name, cadence } = extractNameAndCadence(ritual.name);
+
+    nameEl.textContent = name;
+    keyEl.textContent = `Ritual key: ${ritual.ritual_key}`;
+
+    instantBadge.hidden = !ritual.instant_runs;
+    manualBadge.hidden = ritual.instant_runs;
+
+    runBehaviourEl.textContent = ritual.instant_runs
+      ? 'Agents trigger and auto-complete this run immediately.'
+      : 'Agents stage the run and wait for a manual wrap-up when ready.';
+
+    cadenceChip.hidden = false;
+    cadenceChip.textContent = cadence ? `Cadence • ${cadence}` : 'Cadence • On demand';
+
+    updateSubtitle(ritual);
+    renderInputs(ritual.inputs || []);
+    renderRuns(ritual.runs || []);
+  };
+
+  const loadRitual = async () => {
+    if (!ritualKeyParam) {
+      nameEl.textContent = 'Ritual not specified';
+      keyEl.textContent = 'Add ?ritual=<ritual_key> to the URL to load a ritual.';
+      createRunButton.disabled = true;
+      setToast('Missing ritual key in URL', 'error');
+      return;
+    }
+
+    try {
+      createRunButton.disabled = false;
+      createRunButton.textContent = 'Create run now';
+      const data = await fetchJson(`/rituals/${encodeURIComponent(ritualKeyParam)}`);
+      if (!data || !data.ritual) {
+        throw new Error('ritual_not_found');
+      }
+      renderRitual(data.ritual);
+    } catch (error) {
+      nameEl.textContent = 'Unable to load ritual';
+      keyEl.textContent = ritualKeyParam ? `Ritual key: ${ritualKeyParam}` : '';
+      createRunButton.disabled = true;
+      setToast(error.message || 'Unable to load ritual', 'error');
+    }
+  };
+
+  createRunButton.addEventListener('click', async () => {
+    if (!ritualKeyParam) {
+      return;
+    }
+
+    createRunButton.disabled = true;
+    const originalLabel = createRunButton.textContent;
+    createRunButton.textContent = 'Creating…';
+    setToast('');
+
+    try {
+      const data = await fetchJson(`/rituals/${encodeURIComponent(ritualKeyParam)}/runs`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      });
+
+      if (!data || !data.run) {
+        throw new Error('Run creation failed');
+      }
+
+      const message = data.run.status === 'complete' ? 'Run complete' : 'Run created';
+      setToast(message, 'success');
+      await loadRitual();
+    } catch (error) {
+      setToast(error.message || 'Unable to create run', 'error');
+      createRunButton.disabled = false;
+      createRunButton.textContent = originalLabel;
+    }
+  });
+
+  loadRitual();
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -14,6 +14,12 @@ body {
     linear-gradient(180deg, #f9fafb 0%, #eff4ff 60%, #f8f9fb 100%);
 }
 
+.detail-body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 .app-header {
   padding: 3rem 1.5rem 1.5rem;
   text-align: center;
@@ -52,6 +58,30 @@ body {
   padding: 0 1.5rem 3.5rem;
   max-width: 1100px;
   margin: 0 auto;
+}
+
+.detail-layout {
+  display: grid;
+  gap: 1.5rem;
+  padding: 0 1.5rem 3.5rem;
+  width: min(960px, 100%);
+  margin: 0 auto 3rem;
+}
+
+.detail-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.detail-card-header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.detail-card-support {
+  margin: 0;
+  color: #475467;
+  font-size: 0.95rem;
 }
 
 @media (min-width: 960px) {
@@ -278,6 +308,188 @@ button.secondary:hover {
   text-decoration: underline;
 }
 
+.page-header {
+  padding: 2.5rem 1.5rem 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+  text-align: left;
+}
+
+.page-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.back-link {
+  color: #4f46e5;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.ritual-hero {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.ritual-heading {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.ritual-heading h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 2.75rem);
+}
+
+.ritual-key {
+  margin: 0;
+  color: #6366f1;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.ritual-subtitle {
+  margin: 0;
+  color: #475467;
+}
+
+.ritual-meta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: #3730a3;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.runs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.run-item {
+  border: 1px solid rgba(79, 70, 229, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.run-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.run-key {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: rgba(59, 130, 246, 0.16);
+  color: #1d4ed8;
+}
+
+.status-chip.status-complete {
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
+}
+
+.status-chip.status-planned {
+  background: rgba(249, 115, 22, 0.16);
+  color: #c2410c;
+}
+
+.status-chip.status-in_progress {
+  background: rgba(59, 130, 246, 0.16);
+  color: #1d4ed8;
+}
+
+.run-meta {
+  margin: 0;
+  color: #475467;
+  font-size: 0.9rem;
+}
+
+.run-activity {
+  margin: 0;
+  color: #4f46e5;
+  font-size: 0.9rem;
+}
+
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  padding: 0.8rem 1.2rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+  font-weight: 600;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.3);
+  transition: opacity 0.3s ease;
+}
+
+.toast.success {
+  background: rgba(34, 197, 94, 0.95);
+}
+
+.toast.error {
+  background: rgba(220, 38, 38, 0.95);
+}
+
+.toast.info {
+  background: rgba(59, 130, 246, 0.95);
+}
+
+.toast[hidden] {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ritual-link {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.ritual-link:focus .ritual-item,
+.ritual-link:hover .ritual-item {
+  border-color: rgba(79, 70, 229, 0.45);
+  box-shadow: 0 16px 28px rgba(79, 70, 229, 0.2);
+}
+
 .attention-item {
   border-radius: 16px;
   border: 1px solid rgba(220, 38, 38, 0.2);
@@ -322,6 +534,19 @@ button.secondary:hover {
     border: 1px solid rgba(99, 102, 241, 0.2);
   }
 
+  .detail-card-support,
+  .ritual-subtitle {
+    color: #cbd5f5;
+  }
+
+  .ritual-key {
+    color: #a5b4fc;
+  }
+
+  .back-link {
+    color: #a5b4fc;
+  }
+
   .input-label {
     color: #e2e8f0;
   }
@@ -342,9 +567,51 @@ button.secondary:hover {
     color: #fcd34d;
   }
 
+  .chip {
+    background: rgba(129, 140, 248, 0.25);
+    color: #e0e7ff;
+  }
+
   .inputs-list li {
     background: rgba(99, 102, 241, 0.25);
     color: #c7d2fe;
+  }
+
+  .run-item {
+    background: rgba(30, 41, 59, 0.8);
+    border-color: rgba(99, 102, 241, 0.3);
+  }
+
+  .run-key {
+    color: #e2e8f0;
+  }
+
+  .run-meta {
+    color: #cbd5f5;
+  }
+
+  .run-activity {
+    color: #a5b4fc;
+  }
+
+  .status-chip {
+    background: rgba(59, 130, 246, 0.35);
+    color: #bfdbfe;
+  }
+
+  .status-chip.status-complete {
+    background: rgba(34, 197, 94, 0.35);
+    color: #bbf7d0;
+  }
+
+  .status-chip.status-planned {
+    background: rgba(249, 115, 22, 0.35);
+    color: #fed7aa;
+  }
+
+  .status-chip.status-in_progress {
+    background: rgba(59, 130, 246, 0.35);
+    color: #bfdbfe;
   }
 
   .attention-item {


### PR DESCRIPTION
## Summary
- add a dedicated ritual detail page that surfaces cadence hints, links, and recent runs
- wire the dashboard ritual list to the new page and add toast feedback when starting a run
- expand styling for the detail layout, including dark-mode tweaks, and check off the ritual page task

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dc81300f308329b2ba9fd2249b8917