### PR TITLE
Add ritual detail page with cadence parsing

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -50,7 +50,8 @@
 - [x] **Home**: single-line ritual creator + Upcoming + Needs Attention
   - Completed: Added static home dashboard with intent parser, ritual list, and attention feed backed by existing APIs. — tests: `npm test`, `npm run e2e:smoke`
   - **AC:** Can create a ritual by typing “Trash day Fridays 7am https://link”; ritual appears; link listed.
-- [ ] **Ritual page**: show cadence, instant badge, default inputs, “Create run now”
+- [x] **Ritual page**: show cadence, instant badge, default inputs, “Create run now” — tests: `npm test`, `npm run e2e:smoke`
+  - Completed: Added cadence parsing, ritual detail view with instant badge, saved inputs, and run launcher with success toast.
   - **AC:** Button creates a run; if instant, a toast shows “Run complete”.
 - [ ] **Run mini-hub**: show status, next triggers (mock), activity log, attention items
   - **AC:** Attention item created via API is visible and can be resolved (mock).

--- a/public/ritual.html
+++ b/public/ritual.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ritual • WeaveOS</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body class="detail-body">
+    <header class="detail-header">
+      <a class="back-link" href="/">← Back to dashboard</a>
+      <div class="detail-heading">
+        <h1 id="ritual-name">Loading ritual…</h1>
+        <p id="ritual-key" class="ritual-key" aria-live="polite"></p>
+      </div>
+    </header>
+    <main class="layout detail-layout" aria-live="polite">
+      <section class="card detail-card" aria-labelledby="overview-title">
+        <div class="card-header">
+          <div>
+            <h2 id="overview-title">Overview</h2>
+            <p class="card-support">Cadence, instant-run behaviour, and saved references.</p>
+          </div>
+          <span id="instant-badge" class="badge" hidden>Instant runs</span>
+        </div>
+        <dl class="meta-grid">
+          <div class="meta-row">
+            <dt>Cadence</dt>
+            <dd id="ritual-cadence">Detecting cadence…</dd>
+          </div>
+          <div class="meta-row">
+            <dt>Instant runs</dt>
+            <dd id="ritual-instant">Loading…</dd>
+          </div>
+        </dl>
+        <div class="inputs-section">
+          <h3>Default inputs</h3>
+          <ul id="inputs-list" class="inputs-list" role="list"></ul>
+          <p id="inputs-empty" class="empty-state" hidden>No saved links yet.</p>
+        </div>
+      </section>
+      <section class="card detail-card" aria-labelledby="runs-title">
+        <div class="card-header">
+          <div>
+            <h2 id="runs-title">Recent runs</h2>
+            <p class="card-support">Latest activity for this ritual.</p>
+          </div>
+          <button id="create-run" type="button">Create run now</button>
+        </div>
+        <ul id="run-list" class="run-list" role="list"></ul>
+        <p id="runs-empty" class="empty-state" hidden>No runs yet. Trigger one to see updates.</p>
+      </section>
+    </main>
+    <div id="toast" class="toast" role="status" aria-live="assertive" hidden></div>
+    <script src="/ritual.js" defer></script>
+  </body>
+</html>

--- a/public/ritual.js
+++ b/public/ritual.js
@@ -1,0 +1,216 @@
+(function () {
+  const params = new URLSearchParams(window.location.search);
+  const ritualKeyParam = params.get('ritual');
+  const nameEl = document.getElementById('ritual-name');
+  const keyEl = document.getElementById('ritual-key');
+  const cadenceEl = document.getElementById('ritual-cadence');
+  const instantEl = document.getElementById('ritual-instant');
+  const instantBadge = document.getElementById('instant-badge');
+  const inputsList = document.getElementById('inputs-list');
+  const inputsEmpty = document.getElementById('inputs-empty');
+  const runList = document.getElementById('run-list');
+  const runsEmpty = document.getElementById('runs-empty');
+  const createRunButton = document.getElementById('create-run');
+  const toast = document.getElementById('toast');
+
+  const showToast = (message, tone = 'info') => {
+    toast.textContent = message;
+    toast.className = `toast ${tone}`.trim();
+    toast.hidden = false;
+    clearTimeout(showToast.timeoutId);
+    showToast.timeoutId = window.setTimeout(() => {
+      toast.hidden = true;
+    }, 4000);
+  };
+
+  showToast.timeoutId = null;
+
+  const formatRelativeTime = (input) => {
+    const date = input instanceof Date ? input : new Date(input);
+    if (Number.isNaN(date.getTime())) {
+      return 'just now';
+    }
+
+    const deltaSeconds = Math.round((Date.now() - date.getTime()) / 1000);
+    const absSeconds = Math.abs(deltaSeconds);
+
+    const thresholds = [
+      { limit: 60, unit: 'second', value: deltaSeconds },
+      { limit: 3600, unit: 'minute', value: Math.round(deltaSeconds / 60) },
+      { limit: 86400, unit: 'hour', value: Math.round(deltaSeconds / 3600) },
+      { limit: 604800, unit: 'day', value: Math.round(deltaSeconds / 86400) },
+    ];
+
+    const match = thresholds.find((entry) => absSeconds < entry.limit);
+    if (match) {
+      const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+      return rtf.format(match.value, match.unit);
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+    }).format(date);
+  };
+
+  const formatRunStatus = (run) => {
+    const statusLabels = {
+      planned: 'Scheduled',
+      in_progress: 'In progress',
+      complete: 'Completed',
+    };
+
+    const label = statusLabels[run.status] || 'Active';
+    return `${label} • ${formatRelativeTime(run.updated_at || run.created_at)}`;
+  };
+
+  const renderInputs = (inputs = []) => {
+    inputsList.innerHTML = '';
+    if (!inputs.length) {
+      inputsEmpty.hidden = false;
+      return;
+    }
+
+    inputsEmpty.hidden = true;
+    inputs.forEach((input) => {
+      const li = document.createElement('li');
+      if (input.type === 'external_link') {
+        const anchor = document.createElement('a');
+        anchor.href = input.value;
+        anchor.target = '_blank';
+        anchor.rel = 'noreferrer noopener';
+        anchor.textContent = input.label || input.value;
+        li.appendChild(anchor);
+      } else {
+        li.textContent = input.value;
+      }
+      inputsList.appendChild(li);
+    });
+  };
+
+  const renderRuns = (runs = []) => {
+    runList.innerHTML = '';
+    if (!runs.length) {
+      runsEmpty.hidden = false;
+      return;
+    }
+
+    runsEmpty.hidden = true;
+    runs
+      .slice()
+      .sort((a, b) => {
+        const aTime = new Date(a.updated_at || a.created_at || 0).getTime();
+        const bTime = new Date(b.updated_at || b.created_at || 0).getTime();
+        return bTime - aTime;
+      })
+      .slice(0, 5)
+      .forEach((run) => {
+        const item = document.createElement('li');
+        item.className = 'run-item';
+
+        const status = document.createElement('span');
+        status.className = `run-status ${run.status}`;
+        status.textContent = run.status.replace(/_/g, ' ');
+        item.appendChild(status);
+
+        const meta = document.createElement('span');
+        meta.className = 'run-meta';
+        meta.textContent = formatRunStatus(run);
+        item.appendChild(meta);
+
+        runList.appendChild(item);
+      });
+  };
+
+  const fetchJson = async (input, init) => {
+    const response = await fetch(input, init);
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      const errorMessage = errorBody.error || response.statusText || 'Request failed';
+      throw new Error(errorMessage);
+    }
+    return response.json();
+  };
+
+  const applyRitual = (ritual) => {
+    nameEl.textContent = ritual.name;
+    document.title = `${ritual.name} • WeaveOS`;
+    if (keyEl) {
+      keyEl.textContent = `Ritual key: ${ritual.ritual_key}`;
+    }
+
+    if (cadenceEl) {
+      cadenceEl.textContent = ritual.cadence || 'Cadence not provided yet.';
+    }
+
+    if (instantEl) {
+      instantEl.textContent = ritual.instant_runs
+        ? 'Agents auto-complete this run.'
+        : 'Agents will start the run; you wrap it up.';
+    }
+
+    if (instantBadge) {
+      instantBadge.hidden = !ritual.instant_runs;
+      if (!instantBadge.hidden) {
+        instantBadge.textContent = 'Instant runs';
+      }
+    }
+
+    renderInputs(Array.isArray(ritual.inputs) ? ritual.inputs : []);
+    renderRuns(Array.isArray(ritual.runs) ? ritual.runs : []);
+  };
+
+  const loadRitual = async () => {
+    if (!ritualKeyParam) {
+      showToast('Missing ritual key in the URL.', 'error');
+      createRunButton.disabled = true;
+      nameEl.textContent = 'Ritual not found';
+      return;
+    }
+
+    try {
+      const data = await fetchJson(`/rituals/${encodeURIComponent(ritualKeyParam)}`);
+      if (!data.ritual) {
+        throw new Error('ritual_not_found');
+      }
+      applyRitual(data.ritual);
+    } catch (error) {
+      nameEl.textContent = 'Ritual not found';
+      showToast(error.message || 'Unable to load ritual', 'error');
+      createRunButton.disabled = true;
+    }
+  };
+
+  createRunButton.addEventListener('click', async () => {
+    if (!ritualKeyParam) {
+      return;
+    }
+
+    createRunButton.disabled = true;
+    showToast('Creating run…');
+
+    try {
+      const data = await fetchJson(`/rituals/${encodeURIComponent(ritualKeyParam)}/runs`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      });
+
+      if (!data.run) {
+        throw new Error('run_not_created');
+      }
+
+      const run = data.run;
+      showToast(run.status === 'complete' ? 'Run complete' : 'Run started', 'success');
+      await loadRitual();
+    } catch (error) {
+      showToast(error.message || 'Unable to create run', 'error');
+    } finally {
+      createRunButton.disabled = false;
+    }
+  });
+
+  loadRitual();
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -14,6 +14,11 @@ body {
     linear-gradient(180deg, #f9fafb 0%, #eff4ff 60%, #f8f9fb 100%);
 }
 
+.detail-body {
+  display: flex;
+  flex-direction: column;
+}
+
 .app-header {
   padding: 3rem 1.5rem 1.5rem;
   text-align: center;
@@ -46,12 +51,53 @@ body {
   font-size: 1.05rem;
 }
 
+.detail-header {
+  padding: 2.5rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.back-link {
+  color: #4f46e5;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.back-link:hover,
+.back-link:focus {
+  text-decoration: underline;
+}
+
+.detail-heading {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.detail-heading h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.ritual-key {
+  margin: 0;
+  color: #475467;
+  font-size: 0.95rem;
+}
+
 .layout {
   display: grid;
   gap: 1.5rem;
   padding: 0 1.5rem 3.5rem;
   max-width: 1100px;
   margin: 0 auto;
+}
+
+.detail-layout {
+  width: 100%;
 }
 
 @media (min-width: 960px) {
@@ -78,6 +124,11 @@ body {
   padding: 2rem;
 }
 
+.detail-card {
+  display: grid;
+  gap: 1.5rem;
+}
+
 .card.stack {
   display: grid;
   gap: 1.25rem;
@@ -93,6 +144,42 @@ body {
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
+}
+
+.meta-grid {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+}
+
+.meta-row {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.meta-row dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6366f1;
+  margin: 0;
+}
+
+.meta-row dd {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.inputs-section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.inputs-section h3 {
+  margin: 0;
+  font-size: 1rem;
 }
 
 .card-support {
@@ -220,6 +307,21 @@ button.secondary:hover {
 .ritual-name {
   font-size: 1.1rem;
   font-weight: 600;
+  color: #1f2937;
+  text-decoration: none;
+}
+
+.ritual-name:hover,
+.ritual-name:focus {
+  text-decoration: underline;
+  color: #4f46e5;
+}
+
+.ritual-cadence {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #1d4ed8;
+  font-weight: 500;
 }
 
 .ritual-behaviour {
@@ -278,6 +380,68 @@ button.secondary:hover {
   text-decoration: underline;
 }
 
+.run-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.run-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(79, 70, 229, 0.12);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.run-status {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+  color: #4f46e5;
+}
+
+.run-status.in_progress {
+  color: #2563eb;
+}
+
+.run-status.complete {
+  color: #16a34a;
+}
+
+.run-meta {
+  font-size: 0.9rem;
+  color: #475467;
+}
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 2rem;
+  transform: translateX(-50%);
+  padding: 0.9rem 1.4rem;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.9);
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.18);
+  z-index: 1000;
+  transition: opacity 0.2s ease;
+}
+
+.toast.success {
+  background: rgba(22, 163, 74, 0.9);
+}
+
+.toast.error {
+  background: rgba(220, 38, 38, 0.9);
+}
+
 .attention-item {
   border-radius: 16px;
   border: 1px solid rgba(220, 38, 38, 0.2);
@@ -322,6 +486,18 @@ button.secondary:hover {
     border: 1px solid rgba(99, 102, 241, 0.2);
   }
 
+  .back-link {
+    color: #c7d2fe;
+  }
+
+  .detail-heading h1 {
+    color: #f8fafc;
+  }
+
+  .ritual-key {
+    color: #cbd5f5;
+  }
+
   .input-label {
     color: #e2e8f0;
   }
@@ -342,9 +518,39 @@ button.secondary:hover {
     color: #fcd34d;
   }
 
+  .meta-row dd {
+    color: #e2e8f0;
+  }
+
+  .ritual-name {
+    color: #f9fafb;
+  }
+
+  .ritual-name:hover,
+  .ritual-name:focus {
+    color: #c7d2fe;
+  }
+
+  .ritual-cadence {
+    color: #93c5fd;
+  }
+
   .inputs-list li {
     background: rgba(99, 102, 241, 0.25);
     color: #c7d2fe;
+  }
+
+  .run-item {
+    background: rgba(30, 41, 59, 0.65);
+    border-color: rgba(99, 102, 241, 0.25);
+  }
+
+  .run-meta {
+    color: #cbd5f5;
+  }
+
+  .toast {
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.4);
   }
 
   .attention-item {


### PR DESCRIPTION
## Summary
- parse cadence phrases from ritual intent and store them on rituals
- link rituals from the dashboard to a new ritual detail page showing cadence, inputs, and instant run status
- allow triggering runs from the ritual page with toast feedback and refreshed activity styling updates

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dc85d3aa508329b83d8352124ddefc