### PR TITLE
Brand run keys and show friendly labels

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -110,6 +110,34 @@
     }).format(date);
   };
 
+  const formatRunKeyLabel = (runKey, ritualName) => {
+    const prefix = 'Weave run';
+    const safeName = typeof ritualName === 'string' && ritualName.trim().length > 0 ? ritualName.trim() : null;
+
+    if (typeof runKey !== 'string' || runKey.trim().length === 0) {
+      return safeName ? `${prefix} • ${safeName}` : prefix;
+    }
+
+    const runKeyPattern = /^weave-run-(.+)-(\d{4}-\d{2}-\d{2}T.+)$/;
+    const match = runKey.trim().match(runKeyPattern);
+
+    if (!match) {
+      if (safeName) {
+        return `${prefix} • ${safeName} • ${runKey.trim()}`;
+      }
+      return `${prefix} • ${runKey.trim()}`;
+    }
+
+    const [, rawRitualKey, timestamp] = match;
+    const labelName = safeName || rawRitualKey.replace(/-/g, ' ').trim();
+    const timestampDate = new Date(timestamp);
+    const formattedDate = Number.isNaN(timestampDate.getTime())
+      ? timestamp
+      : new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(timestampDate);
+
+    return `${prefix} • ${labelName} • ${formattedDate}`;
+  };
+
   const describeRunBehaviour = (ritual) =>
     ritual.instant_runs
       ? 'Auto-completes the moment an agent triggers it.'
@@ -247,7 +275,8 @@
       li.appendChild(message);
 
       const context = document.createElement('span');
-      context.textContent = `${item.type.replace(/_/g, ' ')} • Run ${item.run_key} • ${item.ritual_name}`;
+      const runLabel = formatRunKeyLabel(item.run_key, item.ritual_name);
+      context.textContent = `${item.type.replace(/_/g, ' ')} • ${runLabel}`;
       li.appendChild(context);
 
       attentionList.appendChild(li);

--- a/src/app.ts
+++ b/src/app.ts
@@ -328,7 +328,10 @@ const handleGetRitual = (
   sendJson(response, 200, { ritual: normalizeRitualForResponse(ritual) });
 };
 
-const createRunKey = (): string => new Date().toISOString();
+const createRunKey = (ritualKey: string): string => {
+  const timestamp = new Date().toISOString();
+  return `weave-run-${ritualKey}-${timestamp}`;
+};
 
 const handleCreateRun = async (
   state: AppState,
@@ -367,7 +370,7 @@ const handleCreateRun = async (
     return;
   }
 
-  const runKey = providedRunKey ?? createRunKey();
+  const runKey = providedRunKey ?? createRunKey(ritual.ritual_key);
 
   if (state.runs.has(runKey)) {
     sendJson(response, 409, { error: 'run_already_exists' });


### PR DESCRIPTION
## Summary
- brand generated run keys with the ritual key and timestamp for clearer identifiers
- update integration tests to expect branded run keys
- add client helpers to format run key labels across ritual details and attention feed

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dc8987a55883299218cff3106ae361