### PR TITLE
Add run mini-hub and run detail endpoint

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -53,7 +53,8 @@
 - [x] **Ritual page**: show cadence, instant badge, default inputs, “Create run now” — tests: `npm test`, `npm run e2e:smoke`
   - Completed: Added dedicated ritual detail view with run kick-off flow and success toast for instant runs.
   - **AC:** Button creates a run; if instant, a toast shows “Run complete”.
-- [ ] **Run mini-hub**: show status, next triggers (mock), activity log, attention items
+- [x] **Run mini-hub**: show status, next triggers (mock), activity log, attention items — tests: `npm test`, `npm run e2e:smoke`
+  - Completed: Added run detail mini-hub page with mock trigger timeline, attention resolution, and activity feed.
   - **AC:** Attention item created via API is visible and can be resolved (mock).
 
 ## Phase 6 — Tests

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -123,14 +123,24 @@ paths:
   /runs/{run_id}:
     get:
       summary: Get run
-      description: Placeholder for future implementation.
+      description: Retrieve a run with its parent ritual summary, attention items, and mock next triggers.
       tags: [Runs]
       operationId: getRun
       parameters:
         - $ref: '#/components/parameters/RunId'
       responses:
-        '501':
-          description: Not implemented
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetRunResponse'
+        '404':
+          description: Run not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /runs/{run_id}/artifacts:
     get:
       summary: List run artifacts
@@ -382,6 +392,35 @@ components:
           description: Timeline of notable run events.
           items:
             $ref: '#/components/schemas/ActivityLogEntry'
+    RitualSummary:
+      type: object
+      required:
+        - ritual_key
+        - name
+        - instant_runs
+        - inputs
+        - created_at
+        - updated_at
+      properties:
+        ritual_key:
+          type: string
+          example: trash-day
+        name:
+          type: string
+          example: Trash day pickup
+        instant_runs:
+          type: boolean
+        inputs:
+          type: array
+          description: Optional default inputs inherited by runs.
+          items:
+            $ref: '#/components/schemas/RitualInput'
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     Ritual:
       type: object
       required:
@@ -471,6 +510,53 @@ components:
       properties:
         run:
           $ref: '#/components/schemas/Run'
+    NextTrigger:
+      type: object
+      required: [event, label, status, description]
+      properties:
+        event:
+          type: string
+          description: Trigger identifier that will fire next.
+          enum:
+            - on_run_planned
+            - before_run_start
+            - on_run_start
+            - on_artifact_published
+            - on_run_complete
+            - on_attention_resolved
+        label:
+          type: string
+          description: Human readable label for the trigger.
+        status:
+          type: string
+          description: Mock lifecycle for the trigger.
+          enum: [queued, pending, active, complete]
+        description:
+          type: string
+          description: Short note explaining what will happen.
+    GetRunResponse:
+      type: object
+      required:
+        - run
+        - next_triggers
+        - attention_items
+      properties:
+        run:
+          $ref: '#/components/schemas/Run'
+        ritual:
+          $ref: '#/components/schemas/RitualSummary'
+          nullable: true
+          description: Parent ritual summary when available.
+        next_triggers:
+          type: array
+          description: Upcoming mock trigger timeline for the run.
+          items:
+            $ref: '#/components/schemas/NextTrigger'
+        attention_items:
+          type: array
+          description: Attention items currently attached to the run.
+          items:
+            $ref: '#/components/schemas/AttentionItem'
     ActivityLogEntry:
       type: object
       required:

--- a/public/app.js
+++ b/public/app.js
@@ -274,8 +274,10 @@
       message.textContent = item.message;
       li.appendChild(message);
 
-      const context = document.createElement('span');
+      const context = document.createElement('a');
       const runLabel = formatRunKeyLabel(item.run_key, item.ritual_name);
+      context.href = `/run.html?run=${encodeURIComponent(item.run_key)}`;
+      context.className = 'attention-context';
       context.textContent = `${item.type.replace(/_/g, ' ')} • ${runLabel}`;
       li.appendChild(context);
 

--- a/public/ritual.js
+++ b/public/ritual.js
@@ -197,7 +197,12 @@
 
     sorted.slice(0, 5).forEach((run) => {
       const li = document.createElement('li');
-      li.className = 'run-item';
+      const link = document.createElement('a');
+      link.href = `/run.html?run=${encodeURIComponent(run.run_key)}`;
+      link.className = 'run-link';
+
+      const card = document.createElement('div');
+      card.className = 'run-item';
 
       const header = document.createElement('div');
       header.className = 'run-header';
@@ -212,14 +217,14 @@
       badge.textContent = statusLabel(run.status);
       header.appendChild(badge);
 
-      li.appendChild(header);
+      card.appendChild(header);
 
       const meta = document.createElement('p');
       meta.className = 'run-meta';
       meta.textContent = `${formatAbsoluteTimestamp(run.updated_at || run.created_at)} • ${formatRelativeTime(
         run.updated_at || run.created_at,
       )}`;
-      li.appendChild(meta);
+      card.appendChild(meta);
 
       if (Array.isArray(run.activity_log) && run.activity_log.length > 0) {
         const latestLog = run.activity_log[run.activity_log.length - 1];
@@ -227,10 +232,12 @@
           const activity = document.createElement('p');
           activity.className = 'run-activity';
           activity.textContent = latestLog.message;
-          li.appendChild(activity);
+          card.appendChild(activity);
         }
       }
 
+      link.appendChild(card);
+      li.appendChild(link);
       runsList.appendChild(li);
     });
   };

--- a/public/run.html
+++ b/public/run.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Run • WeaveOS</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body class="detail-body">
+    <header class="page-header">
+      <nav class="page-nav">
+        <a class="back-link" href="/">← Back to dashboard</a>
+        <a id="ritual-nav-link" class="pill-link" href="#" hidden>View parent ritual</a>
+      </nav>
+      <div class="run-hero">
+        <div class="run-heading">
+          <p id="run-key" class="run-key-label">Loading run…</p>
+          <h1 id="run-title">Fetching run</h1>
+        </div>
+        <div class="run-hero-meta">
+          <span id="run-status-chip" class="status-chip">Loading</span>
+          <span id="run-updated" class="run-updated">—</span>
+        </div>
+      </div>
+      <p id="run-subtitle" class="run-subtitle">WeaveOS is gathering the latest activity.</p>
+    </header>
+    <main class="detail-layout">
+      <section class="card detail-card">
+        <div class="detail-card-header">
+          <h2>Run overview</h2>
+          <p class="detail-card-support">Status, ownership, and inherited inputs.</p>
+        </div>
+        <dl class="run-overview">
+          <div class="run-overview-row">
+            <dt>Status</dt>
+            <dd id="run-status">Loading…</dd>
+          </div>
+          <div class="run-overview-row">
+            <dt>Ritual</dt>
+            <dd id="run-ritual">—</dd>
+          </div>
+          <div class="run-overview-row">
+            <dt>Last update</dt>
+            <dd id="run-last-update">—</dd>
+          </div>
+        </dl>
+        <div class="run-inputs">
+          <h3 class="section-subtitle">Default inputs</h3>
+          <ul id="run-inputs" class="inputs-list"></ul>
+          <p id="run-inputs-empty" class="empty-state" hidden>No default inputs linked to this run.</p>
+        </div>
+      </section>
+      <section class="card detail-card">
+        <div class="detail-card-header">
+          <h2>Next triggers</h2>
+          <p class="detail-card-support">Mock timeline for upcoming agent actions.</p>
+        </div>
+        <ul id="triggers-list" class="trigger-list" role="list"></ul>
+        <p id="triggers-empty" class="empty-state" hidden>This run is wrapped up — no pending triggers.</p>
+      </section>
+      <section class="card detail-card">
+        <div class="detail-card-header">
+          <h2>Attention items</h2>
+          <p class="detail-card-support">Resolve blockers to keep agents moving.</p>
+        </div>
+        <ul id="attention-list" class="attention-list" role="list"></ul>
+        <p id="attention-empty" class="empty-state" hidden>All clear — no attention items.</p>
+      </section>
+      <section class="card detail-card">
+        <div class="detail-card-header">
+          <h2>Activity log</h2>
+          <p class="detail-card-support">Most recent events recorded by the agent.</p>
+        </div>
+        <ul id="activity-list" class="activity-list" role="list"></ul>
+        <p id="activity-empty" class="empty-state" hidden>No activity has been logged yet.</p>
+      </section>
+    </main>
+    <p id="toast" class="toast" role="status" aria-live="polite" hidden></p>
+    <script src="/run.js" defer></script>
+  </body>
+</html>

--- a/public/run.js
+++ b/public/run.js
@@ -1,0 +1,387 @@
+(function () {
+  const params = new URLSearchParams(window.location.search);
+  const runKeyParam = params.get('run') || params.get('run_key') || params.get('id');
+
+  const runTitle = document.getElementById('run-title');
+  const runKeyEl = document.getElementById('run-key');
+  const runStatusChip = document.getElementById('run-status-chip');
+  const runUpdatedEl = document.getElementById('run-updated');
+  const runSubtitle = document.getElementById('run-subtitle');
+  const runStatusText = document.getElementById('run-status');
+  const runRitual = document.getElementById('run-ritual');
+  const runLastUpdate = document.getElementById('run-last-update');
+  const runInputsList = document.getElementById('run-inputs');
+  const runInputsEmpty = document.getElementById('run-inputs-empty');
+  const triggersList = document.getElementById('triggers-list');
+  const triggersEmpty = document.getElementById('triggers-empty');
+  const attentionList = document.getElementById('attention-list');
+  const attentionEmpty = document.getElementById('attention-empty');
+  const activityList = document.getElementById('activity-list');
+  const activityEmpty = document.getElementById('activity-empty');
+  const ritualNavLink = document.getElementById('ritual-nav-link');
+  const toast = document.getElementById('toast');
+
+  const setToast = (message, tone = 'info') => {
+    if (!toast) {
+      return;
+    }
+
+    toast.textContent = message;
+    toast.className = `toast ${tone}`.trim();
+    toast.hidden = message.length === 0;
+  };
+
+  const fetchJson = async (input, init) => {
+    const response = await fetch(input, init);
+    if (!response.ok) {
+      let message = response.statusText || 'Request failed';
+      try {
+        const body = await response.json();
+        if (body && typeof body.error === 'string') {
+          message = body.error.replace(/_/g, ' ');
+        }
+      } catch (error) {
+        // Ignore JSON parse errors.
+      }
+      throw new Error(message);
+    }
+
+    return response.json();
+  };
+
+  const formatRelativeTime = (input) => {
+    if (!input) {
+      return 'just now';
+    }
+
+    const date = input instanceof Date ? input : new Date(input);
+    if (Number.isNaN(date.getTime())) {
+      return 'just now';
+    }
+
+    const deltaSeconds = Math.round((Date.now() - date.getTime()) / 1000);
+    const absSeconds = Math.abs(deltaSeconds);
+
+    const thresholds = [
+      { limit: 60, unit: 'second', value: deltaSeconds },
+      { limit: 3600, unit: 'minute', value: Math.round(deltaSeconds / 60) },
+      { limit: 86400, unit: 'hour', value: Math.round(deltaSeconds / 3600) },
+      { limit: 604800, unit: 'day', value: Math.round(deltaSeconds / 86400) },
+    ];
+
+    const match = thresholds.find((entry) => absSeconds < entry.limit);
+    if (match) {
+      const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+      return rtf.format(match.value, match.unit);
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+    }).format(date);
+  };
+
+  const formatAbsoluteTimestamp = (input) => {
+    const date = input instanceof Date ? input : new Date(input);
+    if (Number.isNaN(date.getTime())) {
+      return 'Unknown time';
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date);
+  };
+
+  const statusLabel = (status) => {
+    switch (status) {
+      case 'planned':
+        return 'Scheduled';
+      case 'in_progress':
+        return 'In progress';
+      case 'complete':
+        return 'Completed';
+      default:
+        return 'Active';
+    }
+  };
+
+  const formatRunKeyLabel = (runKey, ritualName) => {
+    const prefix = 'Weave run';
+    const safeName = typeof ritualName === 'string' && ritualName.trim().length > 0 ? ritualName.trim() : null;
+
+    if (typeof runKey !== 'string' || runKey.trim().length === 0) {
+      return safeName ? `${prefix} • ${safeName}` : prefix;
+    }
+
+    const runKeyPattern = /^weave-run-(.+)-(\d{4}-\d{2}-\d{2}T.+)$/;
+    const match = runKey.trim().match(runKeyPattern);
+
+    if (!match) {
+      if (safeName) {
+        return `${prefix} • ${safeName} • ${runKey.trim()}`;
+      }
+      return `${prefix} • ${runKey.trim()}`;
+    }
+
+    const [, rawRitualKey, timestamp] = match;
+    const labelName = safeName || rawRitualKey.replace(/-/g, ' ').trim();
+    const timestampDate = new Date(timestamp);
+    const formattedDate = Number.isNaN(timestampDate.getTime())
+      ? timestamp
+      : new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(timestampDate);
+
+    return `${prefix} • ${labelName} • ${formattedDate}`;
+  };
+
+  const renderInputs = (inputs = []) => {
+    runInputsList.innerHTML = '';
+    if (!Array.isArray(inputs) || inputs.length === 0) {
+      runInputsEmpty.hidden = false;
+      return;
+    }
+
+    runInputsEmpty.hidden = true;
+    inputs.forEach((input) => {
+      const li = document.createElement('li');
+      if (input.type === 'external_link') {
+        const anchor = document.createElement('a');
+        anchor.href = input.value;
+        anchor.target = '_blank';
+        anchor.rel = 'noreferrer noopener';
+        anchor.textContent = input.label || input.value;
+        li.appendChild(anchor);
+      } else {
+        li.textContent = input.value;
+      }
+      runInputsList.appendChild(li);
+    });
+  };
+
+  const renderTriggers = (triggers = []) => {
+    triggersList.innerHTML = '';
+    if (!Array.isArray(triggers) || triggers.length === 0) {
+      triggersEmpty.hidden = false;
+      return;
+    }
+
+    triggersEmpty.hidden = true;
+    triggers.forEach((trigger) => {
+      const li = document.createElement('li');
+      li.className = `trigger-item trigger-${trigger.status}`;
+
+      const header = document.createElement('div');
+      header.className = 'trigger-header';
+
+      const label = document.createElement('span');
+      label.className = 'trigger-label';
+      label.textContent = trigger.label;
+      header.appendChild(label);
+
+      const status = document.createElement('span');
+      status.className = `trigger-status trigger-status-${trigger.status}`;
+      status.textContent = trigger.status.charAt(0).toUpperCase() + trigger.status.slice(1);
+      header.appendChild(status);
+
+      li.appendChild(header);
+
+      const description = document.createElement('p');
+      description.className = 'trigger-description';
+      description.textContent = trigger.description;
+      li.appendChild(description);
+
+      const eventTag = document.createElement('span');
+      eventTag.className = 'trigger-event';
+      eventTag.textContent = trigger.event.replace(/_/g, ' ');
+      li.appendChild(eventTag);
+
+      triggersList.appendChild(li);
+    });
+  };
+
+  const renderAttention = (items = []) => {
+    attentionList.innerHTML = '';
+    if (!Array.isArray(items) || items.length === 0) {
+      attentionEmpty.hidden = false;
+      return;
+    }
+
+    attentionEmpty.hidden = true;
+    items.forEach((item) => {
+      const li = document.createElement('li');
+      li.className = 'attention-item attention-inline';
+
+      const message = document.createElement('strong');
+      message.textContent = item.message;
+      li.appendChild(message);
+
+      const meta = document.createElement('span');
+      const when = formatRelativeTime(item.created_at);
+      meta.textContent = `${item.type.replace(/_/g, ' ')} • ${when}`;
+      li.appendChild(meta);
+
+      const action = document.createElement('button');
+      action.type = 'button';
+      action.className = 'attention-action';
+      action.dataset.attentionId = item.attention_id;
+      action.textContent = item.resolved ? 'Resolved' : 'Resolve';
+      action.disabled = Boolean(item.resolved);
+      li.appendChild(action);
+
+      attentionList.appendChild(li);
+    });
+  };
+
+  const renderActivity = (activityLog = []) => {
+    activityList.innerHTML = '';
+    if (!Array.isArray(activityLog) || activityLog.length === 0) {
+      activityEmpty.hidden = false;
+      return;
+    }
+
+    activityEmpty.hidden = true;
+
+    const sorted = [...activityLog].sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    );
+
+    sorted.forEach((entry) => {
+      const li = document.createElement('li');
+      li.className = 'activity-item';
+
+      const message = document.createElement('p');
+      message.className = 'activity-message';
+      message.textContent = entry.message || entry.event.replace(/_/g, ' ');
+      li.appendChild(message);
+
+      const meta = document.createElement('span');
+      meta.className = 'activity-meta';
+      meta.textContent = `${formatAbsoluteTimestamp(entry.timestamp)} • ${formatRelativeTime(entry.timestamp)}`;
+      li.appendChild(meta);
+
+      activityList.appendChild(li);
+    });
+  };
+
+  const updateHero = (run, ritual, attentionItems) => {
+    const ritualName = ritual?.name;
+    const label = formatRunKeyLabel(run.run_key, ritualName);
+    runTitle.textContent = label;
+    runKeyEl.textContent = `Run key: ${run.run_key}`;
+
+    const chipLabel = statusLabel(run.status);
+    runStatusChip.textContent = chipLabel;
+    runStatusChip.className = `status-chip status-${run.status}`;
+
+    const lastUpdated = run.updated_at || run.created_at;
+    runUpdatedEl.textContent = `Updated ${formatAbsoluteTimestamp(lastUpdated)} • ${formatRelativeTime(lastUpdated)}`;
+
+    if (ritual && ritual.ritual_key) {
+      const ritualHref = `/ritual.html?ritual=${encodeURIComponent(ritual.ritual_key)}`;
+      runRitual.innerHTML = '';
+      const link = document.createElement('a');
+      link.href = ritualHref;
+      link.className = 'pill-link-inline';
+      link.textContent = ritual.name || ritual.ritual_key;
+      runRitual.appendChild(link);
+
+      ritualNavLink.href = ritualHref;
+      ritualNavLink.hidden = false;
+      ritualNavLink.textContent = `View ritual: ${ritual.name || ritual.ritual_key}`;
+    } else {
+      runRitual.textContent = run.ritual_key;
+      ritualNavLink.hidden = true;
+    }
+
+    const attentionCount = Array.isArray(attentionItems)
+      ? attentionItems.filter((item) => !item.resolved).length
+      : 0;
+
+    if (run.status === 'complete') {
+      runSubtitle.textContent = `Run completed ${formatRelativeTime(lastUpdated)}. Review the log below.`;
+    } else if (attentionCount > 0) {
+      runSubtitle.textContent =
+        attentionCount === 1
+          ? '1 attention item needs resolution to keep things moving.'
+          : `${attentionCount} attention items need resolution to keep things moving.`;
+    } else {
+      runSubtitle.textContent = 'Agents are on it. You can watch the timeline update here.';
+    }
+
+    runStatusText.textContent = `${chipLabel} • ${formatRelativeTime(lastUpdated)}`;
+    runLastUpdate.textContent = `${formatAbsoluteTimestamp(lastUpdated)} (${formatRelativeTime(lastUpdated)})`;
+  };
+
+  const renderRun = (payload) => {
+    const { run, ritual, attention_items: attentionItems = [], next_triggers: triggers = [] } = payload;
+    if (!run) {
+      throw new Error('Run payload missing');
+    }
+
+    updateHero(run, ritual, attentionItems);
+    renderInputs(run.inputs || []);
+    renderTriggers(triggers);
+    renderAttention(attentionItems);
+    renderActivity(run.activity_log || []);
+  };
+
+  const loadRun = async () => {
+    if (!runKeyParam) {
+      runTitle.textContent = 'Run not specified';
+      runSubtitle.textContent = 'Add ?run=<run_key> to the URL to load a run.';
+      runStatusChip.textContent = 'Unknown';
+      runStatusChip.className = 'status-chip';
+      setToast('Missing run key in URL', 'error');
+      return;
+    }
+
+    try {
+      const data = await fetchJson(`/runs/${encodeURIComponent(runKeyParam)}`);
+      renderRun(data);
+      setToast('');
+    } catch (error) {
+      runTitle.textContent = 'Unable to load run';
+      runKeyEl.textContent = runKeyParam ? `Run key: ${runKeyParam}` : '';
+      runSubtitle.textContent = error.message || 'Run lookup failed.';
+      runStatusChip.textContent = 'Error';
+      runStatusChip.className = 'status-chip status-error';
+      setToast(error.message || 'Unable to load run', 'error');
+    }
+  };
+
+  attentionList.addEventListener('click', async (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    if (target.matches('.attention-action')) {
+      const attentionId = target.dataset.attentionId;
+      if (!attentionId) {
+        return;
+      }
+
+      target.disabled = true;
+      target.textContent = 'Resolving…';
+      setToast('Resolving attention item…');
+
+      try {
+        await fetchJson(`/attention/${encodeURIComponent(attentionId)}/resolve`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        setToast('Attention item resolved', 'success');
+        await loadRun();
+      } catch (error) {
+        setToast(error.message || 'Unable to resolve attention item', 'error');
+        target.disabled = false;
+        target.textContent = 'Resolve';
+      }
+    }
+  });
+
+  loadRun();
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -331,6 +331,40 @@ button.secondary:hover {
   text-decoration: underline;
 }
 
+.pill-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.1);
+  color: #4f46e5;
+  font-weight: 600;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.pill-link:hover {
+  background: rgba(79, 70, 229, 0.2);
+}
+
+.pill-link-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.12);
+  color: #4f46e5;
+  font-weight: 600;
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+
+.pill-link-inline:hover {
+  background: rgba(79, 70, 229, 0.18);
+}
+
 .ritual-hero {
   display: flex;
   flex-wrap: wrap;
@@ -368,6 +402,83 @@ button.secondary:hover {
   flex-wrap: wrap;
 }
 
+.run-hero {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.run-heading {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.run-heading h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 2.6rem);
+}
+
+.run-key-label {
+  margin: 0;
+  color: #6366f1;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.run-hero-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  min-width: 200px;
+}
+
+.run-updated {
+  color: #475467;
+  font-size: 0.85rem;
+}
+
+.run-subtitle {
+  margin: 0;
+  color: #475467;
+}
+
+.run-overview {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.run-overview-row {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.run-overview-row dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6366f1;
+  font-weight: 600;
+}
+
+.run-overview-row dd {
+  margin: 0;
+  font-size: 0.98rem;
+  color: #1f2937;
+}
+
+.section-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
 .chip {
   display: inline-flex;
   align-items: center;
@@ -394,6 +505,18 @@ button.secondary:hover {
   padding: 1rem 1.25rem;
   display: grid;
   gap: 0.5rem;
+}
+
+.run-link {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.run-link:focus .run-item,
+.run-link:hover .run-item {
+  border-color: rgba(79, 70, 229, 0.45);
+  box-shadow: 0 16px 28px rgba(79, 70, 229, 0.2);
 }
 
 .run-header {
@@ -434,6 +557,11 @@ button.secondary:hover {
 .status-chip.status-in_progress {
   background: rgba(59, 130, 246, 0.16);
   color: #1d4ed8;
+}
+
+.status-chip.status-error {
+  background: rgba(220, 38, 38, 0.18);
+  color: #b91c1c;
 }
 
 .run-meta {
@@ -490,6 +618,16 @@ button.secondary:hover {
   box-shadow: 0 16px 28px rgba(79, 70, 229, 0.2);
 }
 
+.attention-context {
+  color: #4f46e5;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.attention-context:hover {
+  text-decoration: underline;
+}
+
 .attention-item {
   border-radius: 16px;
   border: 1px solid rgba(220, 38, 38, 0.2);
@@ -499,6 +637,11 @@ button.secondary:hover {
   gap: 0.4rem;
 }
 
+.attention-inline {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+}
+
 .attention-item strong {
   font-size: 1rem;
 }
@@ -506,6 +649,130 @@ button.secondary:hover {
 .attention-item span {
   color: #7f1d1d;
   font-size: 0.9rem;
+}
+
+.attention-inline span,
+.attention-inline a {
+  font-size: 0.85rem;
+}
+
+.attention-action {
+  justify-self: end;
+  background: rgba(79, 70, 229, 0.12);
+  color: #4f46e5;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+}
+
+.attention-action:hover {
+  box-shadow: none;
+  transform: none;
+  background: rgba(79, 70, 229, 0.2);
+}
+
+.attention-action:disabled {
+  background: rgba(79, 70, 229, 0.1);
+  color: #6b7280;
+}
+
+.trigger-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.trigger-item {
+  border-radius: 16px;
+  border: 1px solid rgba(99, 102, 241, 0.22);
+  background: rgba(255, 255, 255, 0.95);
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.trigger-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.trigger-label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.trigger-status {
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.12);
+  color: #4f46e5;
+  text-transform: capitalize;
+}
+
+.trigger-status-active {
+  background: rgba(16, 185, 129, 0.18);
+  color: #047857;
+}
+
+.trigger-status-queued {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.trigger-status-pending {
+  background: rgba(249, 115, 22, 0.18);
+  color: #c2410c;
+}
+
+.trigger-status-complete {
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
+}
+
+.trigger-description {
+  margin: 0;
+  color: #475467;
+  font-size: 0.9rem;
+}
+
+.trigger-event {
+  align-self: flex-start;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6366f1;
+}
+
+.activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.activity-item {
+  display: grid;
+  gap: 0.3rem;
+  border-left: 3px solid rgba(79, 70, 229, 0.35);
+  padding-left: 0.85rem;
+}
+
+.activity-message {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.activity-meta {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.85rem;
 }
 
 .empty-state {
@@ -582,6 +849,14 @@ button.secondary:hover {
     border-color: rgba(99, 102, 241, 0.3);
   }
 
+  .run-meta,
+  .run-updated,
+  .run-subtitle,
+  .trigger-description,
+  .activity-meta {
+    color: #cbd5f5;
+  }
+
   .run-key {
     color: #e2e8f0;
   }
@@ -599,6 +874,11 @@ button.secondary:hover {
     color: #bfdbfe;
   }
 
+  .status-chip.status-error {
+    background: rgba(239, 68, 68, 0.35);
+    color: #fecaca;
+  }
+
   .status-chip.status-complete {
     background: rgba(34, 197, 94, 0.35);
     color: #bbf7d0;
@@ -614,6 +894,17 @@ button.secondary:hover {
     color: #bfdbfe;
   }
 
+  .pill-link,
+  .pill-link-inline,
+  .attention-context {
+    color: #c7d2fe;
+  }
+
+  .pill-link,
+  .pill-link-inline {
+    background: rgba(99, 102, 241, 0.25);
+  }
+
   .attention-item {
     background: rgba(239, 68, 68, 0.2);
     border-color: rgba(248, 113, 113, 0.45);
@@ -621,5 +912,32 @@ button.secondary:hover {
 
   .attention-item span {
     color: #fecaca;
+  }
+
+  .trigger-item {
+    background: rgba(30, 41, 59, 0.8);
+    border-color: rgba(99, 102, 241, 0.35);
+  }
+
+  .trigger-event {
+    color: #a5b4fc;
+  }
+
+  .activity-item {
+    border-color: rgba(99, 102, 241, 0.6);
+  }
+
+  .activity-message {
+    color: #e2e8f0;
+  }
+
+  .attention-action {
+    background: rgba(79, 70, 229, 0.35);
+    color: #c7d2fe;
+  }
+
+  .attention-action:disabled {
+    background: rgba(79, 70, 229, 0.25);
+    color: #94a3b8;
   }
 }

--- a/tests/integration/attention.test.js
+++ b/tests/integration/attention.test.js
@@ -119,8 +119,8 @@ describe('Attention Items API', () => {
 
       assert.ok(listData.attention_items);
       assert.strictEqual(listData.attention_items.length, 2);
-      assert.strictEqual(listData.attention_items[0].message, 'First issue');
-      assert.strictEqual(listData.attention_items[1].message, 'Second issue');
+      assert.strictEqual(listData.attention_items[0].message, 'Second issue');
+      assert.strictEqual(listData.attention_items[1].message, 'First issue');
     } finally {
       server.close();
     }

--- a/tests/integration/runs.test.js
+++ b/tests/integration/runs.test.js
@@ -1,0 +1,128 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createAppServer } = require('../../dist/app.js');
+
+const listen = (server, options) =>
+  new Promise((resolve, reject) => {
+    server.listen(options, () => resolve(server));
+    server.on('error', reject);
+  });
+
+const close = (server) =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+const startServer = async () => {
+  const server = createAppServer();
+  await listen(server, { port: 0, host: '127.0.0.1' });
+  const address = server.address();
+  assert.ok(address && typeof address === 'object', 'server should have an address after listen');
+  return { server, baseUrl: `http://${address.address}:${address.port}` };
+};
+
+test('GET /runs/{run_id} returns run details with attention and triggers', async () => {
+  const { server, baseUrl } = await startServer();
+
+  try {
+    const ritualPayload = {
+      ritual_key: 'laundry-day',
+      name: 'Laundry day Saturday 9am',
+      instant_runs: false,
+      inputs: [
+        {
+          type: 'external_link',
+          value: 'https://household.local/laundry-guide',
+          label: 'Laundry guide',
+        },
+      ],
+    };
+
+    const createRitualResponse = await fetch(`${baseUrl}/rituals`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(ritualPayload),
+    });
+    assert.equal(createRitualResponse.status, 201);
+
+    const createRunResponse = await fetch(`${baseUrl}/rituals/${ritualPayload.ritual_key}/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(createRunResponse.status, 201);
+    const createRunBody = await createRunResponse.json();
+    const { run } = createRunBody;
+    assert.ok(run?.run_key, 'run should include a run_key');
+
+    const initialGetResponse = await fetch(`${baseUrl}/runs/${encodeURIComponent(run.run_key)}`);
+    assert.equal(initialGetResponse.status, 200);
+    const initialPayload = await initialGetResponse.json();
+
+    assert.equal(initialPayload.run.run_key, run.run_key);
+    assert.equal(initialPayload.ritual.ritual_key, ritualPayload.ritual_key);
+    assert.ok(Array.isArray(initialPayload.next_triggers));
+    assert.ok(initialPayload.next_triggers.length > 0, 'next_triggers should include mock entries');
+    assert.deepEqual(initialPayload.run.inputs, ritualPayload.inputs);
+    assert.deepEqual(initialPayload.attention_items, []);
+
+    const attentionRequest = {
+      run_key: run.run_key,
+      type: 'auth_needed',
+      message: 'Re-authenticate the washer app',
+    };
+
+    const createAttentionResponse = await fetch(`${baseUrl}/attention`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(attentionRequest),
+    });
+    assert.equal(createAttentionResponse.status, 201);
+    const attentionBody = await createAttentionResponse.json();
+    const attentionId = attentionBody.attention.attention_id;
+    assert.ok(attentionId);
+
+    const getAfterAttention = await fetch(`${baseUrl}/runs/${encodeURIComponent(run.run_key)}`);
+    assert.equal(getAfterAttention.status, 200);
+    const attentionPayload = await getAfterAttention.json();
+    assert.equal(attentionPayload.attention_items.length, 1);
+    assert.equal(attentionPayload.attention_items[0].attention_id, attentionId);
+    assert.equal(attentionPayload.attention_items[0].resolved, false);
+
+    const resolveResponse = await fetch(`${baseUrl}/attention/${encodeURIComponent(attentionId)}/resolve`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    });
+    assert.equal(resolveResponse.status, 200);
+
+    const getAfterResolve = await fetch(`${baseUrl}/runs/${encodeURIComponent(run.run_key)}`);
+    assert.equal(getAfterResolve.status, 200);
+    const resolvedPayload = await getAfterResolve.json();
+    assert.equal(resolvedPayload.attention_items.length, 1);
+    assert.equal(resolvedPayload.attention_items[0].resolved, true);
+    assert.ok(Array.isArray(resolvedPayload.run.activity_log));
+    assert.ok(
+      resolvedPayload.run.activity_log.some((entry) => entry.event === 'on_attention_resolved'),
+      'activity log should include resolution entry',
+    );
+  } finally {
+    await close(server);
+  }
+});
+
+test('GET /runs/{run_id} returns 404 for unknown run', async () => {
+  const { server, baseUrl } = await startServer();
+
+  try {
+    const response = await fetch(`${baseUrl}/runs/non-existent-run`);
+    assert.equal(response.status, 404);
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary
- implement GET /runs/{id} with ritual summary, attention items, and mock next triggers while hardening path decoding
- add a run mini-hub page with trigger timeline, attention resolution controls, and supporting styles plus dashboard/ritual links
- update OpenAPI documentation and integration tests for the new endpoint and attention ordering

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dc8abc79f88329adfba475de810d15