### PR TITLE
Add unit coverage for rituals, runs, and attention logic

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -59,7 +59,8 @@
 
 ## Phase 6 — Tests
 
-- [ ] Unit tests for rituals, runs, attention items
+- [x] Unit tests for rituals, runs, attention items — tests: `npm test`, `npm run e2e:smoke`
+  - Completed: Added in-memory helpers and unit coverage for ritual creation, run lifecycle (including instant completion), and attention resolution logging.
   - **AC:** CRUD and instant run start/complete covered.
 - [ ] E2E smoke: create ritual → create run → request invocation URL → “done”
   - **AC:** Single command `npm run e2e:smoke` passes.

--- a/tests/unit/attention.test.js
+++ b/tests/unit/attention.test.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { __testing } = require('../../dist/app.js');
+
+test('attention items can be created and resolved with activity log entries', () => {
+  const state = __testing.createInitialState();
+  const ritual = __testing.createRitualRecord(
+    state,
+    {
+      ritual_key: 'holiday-prep',
+      name: 'Holiday Prep',
+      instant_runs: false,
+      inputs: [],
+    },
+    () => new Date('2024-06-05T08:00:00.000Z'),
+  );
+
+  const run = __testing.createRunRecord(
+    state,
+    ritual,
+    { runKey: 'run-holiday', now: () => new Date('2024-06-05T09:00:00.000Z') },
+  );
+
+  const attention = __testing.createAttentionItemRecord(
+    state,
+    run,
+    { type: 'auth_needed', message: 'Please re-authenticate with the city portal' },
+    () => new Date('2024-06-05T09:30:00.000Z'),
+  );
+
+  assert.equal(attention.resolved, false);
+  assert.equal(attention.created_at, '2024-06-05T09:30:00.000Z');
+  assert.equal(state.attentionItems.get(attention.attention_id), attention);
+
+  const resolved = __testing.resolveAttentionItemRecord(
+    state,
+    attention,
+    () => new Date('2024-06-05T10:00:00.000Z'),
+  );
+
+  assert.equal(resolved.resolved, true);
+  assert.equal(resolved.resolved_at, '2024-06-05T10:00:00.000Z');
+  assert.equal(run.updated_at, '2024-06-05T10:00:00.000Z');
+  assert.equal(run.activity_log.length, 1);
+  assert.deepEqual(run.activity_log[0], {
+    timestamp: '2024-06-05T10:00:00.000Z',
+    event: 'on_attention_resolved',
+    message: 'Attention item resolved: auth_needed',
+    metadata: {
+      attention_id: attention.attention_id,
+      attention_type: 'auth_needed',
+      original_message: 'Please re-authenticate with the city portal',
+    },
+  });
+});

--- a/tests/unit/rituals.test.js
+++ b/tests/unit/rituals.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { __testing } = require('../../dist/app.js');
+
+test('createRitualRecord stores a ritual with cloned inputs and timestamps', () => {
+  const state = __testing.createInitialState();
+  const inputs = [
+    { type: 'external_link', value: 'https://city.local/trash', label: 'City schedule' },
+  ];
+  const ritual = __testing.createRitualRecord(
+    state,
+    {
+      ritual_key: 'trash-day',
+      name: 'Trash Day',
+      instant_runs: true,
+      inputs,
+    },
+    () => new Date('2024-06-01T12:00:00.000Z'),
+  );
+
+  assert.equal(state.rituals.size, 1);
+  assert.equal(state.rituals.get('trash-day'), ritual);
+  assert.equal(ritual.created_at, '2024-06-01T12:00:00.000Z');
+  assert.equal(ritual.updated_at, '2024-06-01T12:00:00.000Z');
+  assert.deepEqual(ritual.inputs, inputs);
+  assert.notStrictEqual(ritual.inputs[0], inputs[0], 'inputs should be cloned for safety');
+  inputs[0].value = 'https://city.local/recycling';
+  assert.equal(
+    ritual.inputs[0].value,
+    'https://city.local/trash',
+    'mutating the original input should not affect the stored ritual',
+  );
+  assert.deepEqual(ritual.runs, []);
+});
+
+test('normalizeRitualForResponse returns deep copies of runs and inputs', () => {
+  const state = __testing.createInitialState();
+  const ritual = __testing.createRitualRecord(
+    state,
+    {
+      ritual_key: 'weekly-review',
+      name: 'Weekly Review',
+      instant_runs: false,
+      inputs: [{ type: 'external_link', value: 'https://family.local/plan' }],
+    },
+    () => new Date('2024-06-02T09:00:00.000Z'),
+  );
+
+  const run = __testing.createRunRecord(
+    state,
+    ritual,
+    { runKey: 'run-123', now: () => new Date('2024-06-02T09:05:00.000Z') },
+  );
+
+  const normalized = __testing.normalizeRitualForResponse(ritual);
+
+  assert.notStrictEqual(normalized, ritual);
+  assert.notStrictEqual(normalized.inputs[0], ritual.inputs[0]);
+  assert.notStrictEqual(normalized.runs[0], ritual.runs[0]);
+
+  normalized.inputs[0].value = 'https://changed.local';
+  normalized.runs[0].status = 'complete';
+  normalized.runs[0].inputs[0].value = 'https://altered.local';
+
+  assert.equal(ritual.inputs[0].value, 'https://family.local/plan');
+  assert.equal(run.status, 'planned');
+  assert.equal(run.inputs[0].value, 'https://family.local/plan');
+});

--- a/tests/unit/runs.test.js
+++ b/tests/unit/runs.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { __testing } = require('../../dist/app.js');
+
+test('createRunRecord creates planned runs for scheduled rituals', () => {
+  const state = __testing.createInitialState();
+  const ritual = __testing.createRitualRecord(
+    state,
+    {
+      ritual_key: 'grocery-run',
+      name: 'Saturday Groceries',
+      instant_runs: false,
+      inputs: [{ type: 'external_link', value: 'https://grocer.local/list' }],
+    },
+    () => new Date('2024-06-03T10:00:00.000Z'),
+  );
+
+  const run = __testing.createRunRecord(
+    state,
+    ritual,
+    { runKey: 'run-grocery', now: () => new Date('2024-06-03T11:00:00.000Z') },
+  );
+
+  assert.equal(run.status, 'planned');
+  assert.equal(run.created_at, '2024-06-03T11:00:00.000Z');
+  assert.equal(run.updated_at, '2024-06-03T11:00:00.000Z');
+  assert.equal(state.runs.get('run-grocery'), run);
+  assert.equal(ritual.runs.length, 1);
+  assert.equal(ritual.runs[0], run);
+  assert.notStrictEqual(run.inputs[0], ritual.inputs[0]);
+
+  run.inputs[0].value = 'https://grocer.local/updated-list';
+  assert.equal(ritual.inputs[0].value, 'https://grocer.local/list');
+});
+
+test('createRunRecord completes instant runs immediately', () => {
+  const state = __testing.createInitialState();
+  const ritual = __testing.createRitualRecord(
+    state,
+    {
+      ritual_key: 'take-meds',
+      name: 'Take Morning Medication',
+      instant_runs: true,
+      inputs: [],
+    },
+    () => new Date('2024-06-04T06:55:00.000Z'),
+  );
+
+  const run = __testing.createRunRecord(state, ritual, {
+    runKey: 'run-meds',
+    now: () => new Date('2024-06-04T07:00:00.000Z'),
+    completionTime: () => new Date('2024-06-04T07:00:05.000Z'),
+  });
+
+  assert.equal(run.status, 'complete');
+  assert.equal(run.created_at, '2024-06-04T07:00:00.000Z');
+  assert.equal(run.updated_at, '2024-06-04T07:00:05.000Z');
+  assert.equal(ritual.updated_at, '2024-06-04T07:00:05.000Z');
+});
+
+test('buildNextTriggers reflects run status transitions', () => {
+  const state = __testing.createInitialState();
+  const ritual = __testing.createRitualRecord(
+    state,
+    {
+      ritual_key: 'weekly-planning',
+      name: 'Weekly Planning',
+      instant_runs: false,
+      inputs: [],
+    },
+  );
+
+  const run = __testing.createRunRecord(state, ritual, { runKey: 'run-plan' });
+
+  const plannedTriggers = __testing.buildNextTriggers(run);
+  assert.equal(plannedTriggers.length, 3);
+  assert.equal(plannedTriggers[0].status, 'active');
+  assert.equal(plannedTriggers[plannedTriggers.length - 1].event, 'on_run_start');
+
+  run.status = 'in_progress';
+  const inProgressTriggers = __testing.buildNextTriggers(run);
+  assert.equal(inProgressTriggers.length, 2);
+  assert.equal(inProgressTriggers[0].event, 'on_run_start');
+  assert.equal(inProgressTriggers[0].status, 'active');
+
+  run.status = 'complete';
+  const completeTriggers = __testing.buildNextTriggers(run);
+  assert.equal(completeTriggers.length, 1);
+  assert.equal(completeTriggers[0].event, 'on_run_complete');
+  assert.equal(completeTriggers[0].status, 'complete');
+});


### PR DESCRIPTION
## Summary
- add reusable helpers for creating rituals, runs, and attention records while ensuring response normalization clones state
- expose test-only exports and adjust handlers to reuse the shared helpers
- add unit suites that exercise ritual creation, run lifecycle (including instant runs), and attention resolution plus update TASKS.md

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dd0373fb6483299e2730694c43646a