### PR TITLE
Add end-to-end smoke test for ritual invocation flow

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -62,7 +62,8 @@
 - [x] Unit tests for rituals, runs, attention items — tests: `npm test`, `npm run e2e:smoke`
   - Completed: Added in-memory helpers and unit coverage for ritual creation, run lifecycle (including instant completion), and attention resolution logging.
   - **AC:** CRUD and instant run start/complete covered.
-- [ ] E2E smoke: create ritual → create run → request invocation URL → “done”
+- [x] E2E smoke: create ritual → create run → request invocation URL → “done”
+  - Completed: Added household end-to-end smoke covering ritual creation, instant run completion, and invocation request ([tests/e2e/smoke.test.js](tests/e2e/smoke.test.js)).
   - **AC:** Single command `npm run e2e:smoke` passes.
 
 ## Phase 7 — OpenAPI fidelity

--- a/tests/e2e/smoke.test.js
+++ b/tests/e2e/smoke.test.js
@@ -1,7 +1,103 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const { createAppServer } = require('../../dist/app.js');
 
-// Placeholder to keep the e2e command green while the full harness is developed.
-test('placeholder e2e assertion', () => {
-  assert.equal(true, true);
+const listen = (server, options) =>
+  new Promise((resolve, reject) => {
+    server.listen(options, () => resolve(server));
+    server.on('error', reject);
+  });
+
+const close = (server) =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+const startServer = async () => {
+  const server = createAppServer();
+  await listen(server, { port: 0, host: '127.0.0.1' });
+  const address = server.address();
+  assert.ok(address && typeof address === 'object', 'server should have an address after listen');
+  return { server, baseUrl: `http://${address.address}:${address.port}` };
+};
+
+test('household ritual smoke test', async () => {
+  const { server, baseUrl } = await startServer();
+
+  try {
+    const ritualRequest = {
+      ritual_key: 'trash-day',
+      name: 'Trash day Fridays 7am',
+      instant_runs: true,
+      inputs: [
+        {
+          type: 'external_link',
+          value: 'https://city.local/trash-schedule',
+          label: 'City trash pickup schedule',
+        },
+      ],
+    };
+
+    const createRitualResponse = await fetch(`${baseUrl}/rituals`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(ritualRequest),
+    });
+    assert.equal(createRitualResponse.status, 201, 'ritual creation should succeed');
+    const { ritual } = await createRitualResponse.json();
+    assert.equal(ritual.ritual_key, ritualRequest.ritual_key);
+    assert.equal(ritual.instant_runs, true);
+
+    const createRunResponse = await fetch(`${baseUrl}/rituals/${ritual.ritual_key}/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(createRunResponse.status, 201, 'run creation should succeed');
+    const { run } = await createRunResponse.json();
+    assert.equal(run.ritual_key, ritual.ritual_key);
+    assert.equal(run.status, 'complete', 'instant run should auto-complete');
+
+    const runDetailsResponse = await fetch(`${baseUrl}/runs/${encodeURIComponent(run.run_key)}`);
+    assert.equal(runDetailsResponse.status, 200, 'run details should be fetchable');
+    const runDetails = await runDetailsResponse.json();
+    assert.equal(runDetails.run.status, 'complete');
+    assert.equal(runDetails.ritual.ritual_key, ritual.ritual_key);
+    assert.deepEqual(runDetails.run.inputs, ritualRequest.inputs);
+    assert.ok(Array.isArray(runDetails.next_triggers));
+    assert.ok(
+      runDetails.next_triggers.some((trigger) => trigger.event === 'on_run_complete'),
+      'completed run should surface a wrap-up trigger',
+    );
+
+    const invocationRequest = {
+      capability_id: 'notify.trash-reminder',
+      payload: {
+        ritual_key: ritual.ritual_key,
+        run_key: run.run_key,
+        summary: 'Trash day ritual completed',
+      },
+    };
+
+    const invocationResponse = await fetch(`${baseUrl}/invocations/request`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(invocationRequest),
+    });
+    assert.equal(invocationResponse.status, 200, 'invocation request should return a mock URL');
+    const invocation = await invocationResponse.json();
+    assert.equal(invocation.capability_id, invocationRequest.capability_id);
+    assert.equal(invocation.status, 'pending');
+    assert.ok(invocation.invocation_id.startsWith('inv_'));
+    assert.ok(invocation.idempotency_key.startsWith('idem_'));
+    assert.ok(invocation.invocation_url.startsWith('https://api.example.com/v1/invocations/'));
+  } finally {
+    await close(server);
+  }
 });


### PR DESCRIPTION
## Summary
- replace the placeholder e2e smoke test with a household ritual flow that exercises ritual creation, instant run completion, and mock invocation requests
- mark the Phase 6 smoke-test task as complete in TASKS.md with a note pointing to the new coverage

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dd393d68488329b219e9f68f20be7f