### PR TITLE
Align artifact endpoints with OpenAPI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,7 @@ This repo is optimized for agentic development (Codex or similar). Follow this c
 - Small, composable modules; pure funcs where possible.
 - Idempotency for any action that could be retried.
 - Log structure: `{event, entity, id, status, meta}`.
+
+## OpenAPI parity notes
+
+- `GET /runs/{run_id}/artifacts` and `POST /artifacts` are implemented as 501 Not Implemented placeholders to align the server with the documented contract.

--- a/TASKS.md
+++ b/TASKS.md
@@ -68,7 +68,8 @@
 
 ## Phase 7 — OpenAPI fidelity
 
-- [ ] Ensure handlers match OpenAPI; generate minimal client types (optional)
+- [x] Ensure handlers match OpenAPI; generate minimal client types (optional)
+  - Completed: Added not-implemented artifact handlers matching OpenAPI responses and covered via integration tests. — tests: `npm test`, `npm run e2e:smoke`
   - **AC:** OpenAPI linter is clean; paths ↔ handlers parity documented in AGENTS.md.
 
 ## Phase 8 — Policies (MVP)

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -152,6 +152,10 @@ paths:
       responses:
         '501':
           description: Not implemented
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /artifacts:
     post:
       summary: Create artifact
@@ -161,6 +165,10 @@ paths:
       responses:
         '501':
           description: Not implemented
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /attention:
     post:
       summary: Create attention item

--- a/src/app.ts
+++ b/src/app.ts
@@ -588,6 +588,28 @@ const handleGetRun = (
   });
 };
 
+const handleListRunArtifacts = (
+  _state: AppState,
+  response: ServerResponse,
+  _runKey: string,
+): void => {
+  sendJson(response, 501, { error: 'not_implemented' });
+};
+
+const handleCreateArtifact = async (
+  _state: AppState,
+  request: IncomingMessage,
+  response: ServerResponse,
+): Promise<void> => {
+  try {
+    await readRequestBody(request);
+  } catch (_error) {
+    // Drain errors and continue with the not implemented response.
+  }
+
+  sendJson(response, 501, { error: 'not_implemented' });
+};
+
 const createAttentionId = (): string => `attn_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
 interface CreateAttentionParams {
@@ -1014,6 +1036,16 @@ const handleRequest = async (
       return;
     }
 
+    if (segments.length === 3 && segments[2] === 'artifacts' && method === 'GET') {
+      const runKey = decodePathSegment(segments[1]);
+      if (!runKey) {
+        sendJson(response, 400, { error: 'invalid_run_key' });
+        return;
+      }
+      handleListRunArtifacts(state, response, runKey);
+      return;
+    }
+
     if (segments.length === 3 && segments[2] === 'attention' && method === 'GET') {
       const runKey = decodePathSegment(segments[1]);
       if (!runKey) {
@@ -1035,6 +1067,13 @@ const handleRequest = async (
   if (segments.length > 0 && segments[0] === 'invocations') {
     if (method === 'POST' && segments.length === 2 && segments[1] === 'request') {
       await handleRequestInvocation(state, request, response);
+      return;
+    }
+  }
+
+  if (segments.length > 0 && segments[0] === 'artifacts') {
+    if (method === 'POST' && segments.length === 1) {
+      await handleCreateArtifact(state, request, response);
       return;
     }
   }

--- a/tests/integration/artifacts.test.js
+++ b/tests/integration/artifacts.test.js
@@ -1,0 +1,74 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createAppServer } = require('../../dist/app.js');
+
+const listen = (server, options) =>
+  new Promise((resolve, reject) => {
+    server.listen(options, () => resolve(server));
+    server.on('error', reject);
+  });
+
+const close = (server) =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+const startServer = async () => {
+  const server = createAppServer();
+  await listen(server, { port: 0, host: '127.0.0.1' });
+  const address = server.address();
+  assert.ok(address && typeof address === 'object', 'server should have an address after listen');
+  return { server, baseUrl: `http://${address.address}:${address.port}` };
+};
+
+test('GET /runs/{run_id}/artifacts returns 501 not implemented', async () => {
+  const { server, baseUrl } = await startServer();
+
+  try {
+    const createRitualResponse = await fetch(`${baseUrl}/rituals`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ritual_key: 'artifact-test', name: 'Artifact Test' }),
+    });
+    assert.equal(createRitualResponse.status, 201);
+
+    const createRunResponse = await fetch(`${baseUrl}/rituals/artifact-test/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(createRunResponse.status, 201);
+    const { run } = await createRunResponse.json();
+    assert.ok(run?.run_key, 'expected a run_key in the response');
+
+    const response = await fetch(`${baseUrl}/runs/${encodeURIComponent(run.run_key)}/artifacts`);
+    assert.equal(response.status, 501);
+    const payload = await response.json();
+    assert.deepEqual(payload, { error: 'not_implemented' });
+  } finally {
+    await close(server);
+  }
+});
+
+test('POST /artifacts returns 501 not implemented', async () => {
+  const { server, baseUrl } = await startServer();
+
+  try {
+    const response = await fetch(`${baseUrl}/artifacts`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ context: 'run', run_key: 'sample', type: 'note' }),
+    });
+    assert.equal(response.status, 501);
+    const payload = await response.json();
+    assert.deepEqual(payload, { error: 'not_implemented' });
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary
- add server handlers for the artifact endpoints so they return 501 Not Implemented responses consistent with the OpenAPI contract
- document the parity in AGENTS.md and mark the OpenAPI alignment task as complete
- extend the OpenAPI specification and integration suite to cover the placeholder behavior

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dd4afd63908329a792c25810467bac