### PR TITLE
Add idempotency handling for automations and attention resolves

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -80,7 +80,8 @@
 
 ## Phase 9 — Quality: logs & idempotency
 
-- [ ] Add idempotency keys to automation calls (mock) and attention resolves
+- [x] Add idempotency keys to automation calls (mock) and attention resolves — tests: `npm test`, `npm run e2e:smoke`
+  - Completed: Added header-based idempotency caching for automation registration and attention resolution responses.
   - **AC:** Replaying the same request is safe (no dupes).
 - [ ] Structured logs
   - **AC:** Logs include `{event, run_id, ritual_id?, status}`.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -230,6 +230,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/AttentionId'
         - $ref: '#/components/parameters/HouseholdRole'
+        - $ref: '#/components/parameters/IdempotencyKey'
       responses:
         '200':
           description: OK
@@ -257,6 +258,8 @@ paths:
         specific ritual or apply globally when no `ritual_key` is provided.
       tags: [Automations]
       operationId: createAutomation
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
       requestBody:
         required: true
         content:
@@ -340,6 +343,13 @@ components:
         type: string
         enum: [Owner, Adult, Teen, Guest, Agent]
       description: "Household role of the caller. Only Owners may resolve auth_needed items."
+    IdempotencyKey:
+      in: header
+      name: Idempotency-Key
+      required: false
+      schema:
+        type: string
+      description: Unique key used to safely retry POST requests without duplicating side effects.
   schemas:
     HealthResponse:
       type: object


### PR DESCRIPTION
## Summary
- add in-memory idempotency caching for automation creation and attention resolution handlers
- document the Idempotency-Key header in the OpenAPI contract and mark the task complete
- extend integration coverage for automation and attention flows to assert idempotent retries

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dd67ee11dc83298ecd74ac510d164f