### PR TITLE
Add structured logging for run lifecycle

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -83,7 +83,8 @@
 - [x] Add idempotency keys to automation calls (mock) and attention resolves — tests: `npm test`, `npm run e2e:smoke`
   - Completed: Added header-based idempotency caching for automation registration and attention resolution responses.
   - **AC:** Replaying the same request is safe (no dupes).
-- [ ] Structured logs
+- [x] Structured logs
+  - Completed: Added shared logger emitting structured run and attention lifecycle events with run/ritual context. — tests: `npm test`, `npm run e2e:smoke`
   - **AC:** Logs include `{event, run_id, ritual_id?, status}`.
 
 ## Stretch (optional)

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { createAppServer } from './app';
+import { createAppServer, createConsoleLogger } from './app';
 
 const DEFAULT_PORT = 3000;
 const DEFAULT_HOST = '0.0.0.0';
@@ -6,18 +6,18 @@ const DEFAULT_HOST = '0.0.0.0';
 const port = Number.parseInt(process.env.PORT ?? `${DEFAULT_PORT}`, 10);
 const host = process.env.HOST ?? DEFAULT_HOST;
 
-const server = createAppServer();
+const logger = createConsoleLogger();
+const server = createAppServer({ logger });
 
 server.listen({ port, host }, () => {
-  console.log({
+  logger.info({
     event: 'server.start',
-    entity: 'server',
     status: 'listening',
     meta: { port, host },
   });
 });
 
 server.on('error', (error) => {
-  console.error({ event: 'server.start', entity: 'server', status: 'error', meta: { error } });
+  logger.error({ event: 'server.start', status: 'error', error });
   process.exit(1);
 });

--- a/tests/unit/logging.test.js
+++ b/tests/unit/logging.test.js
@@ -1,0 +1,158 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { __testing } = require('../../dist/app.js');
+
+const createCapturingLogger = () => {
+  const entries = [];
+  return {
+    logger: {
+      info: (entry) => {
+        entries.push({ level: 'info', entry });
+      },
+      error: (entry) => {
+        entries.push({ level: 'error', entry });
+      },
+    },
+    entries,
+  };
+};
+
+test('createRunRecord emits structured log with run and ritual context', () => {
+  const { logger, entries } = createCapturingLogger();
+  const state = __testing.createInitialState(logger);
+  const ritual = __testing.createRitualRecord(
+    state,
+    {
+      ritual_key: 'structured-run',
+      name: 'Structured Run Logging',
+      instant_runs: false,
+      inputs: [],
+    },
+    () => new Date('2024-06-10T09:00:00.000Z'),
+  );
+
+  entries.splice(0, entries.length);
+
+  const run = __testing.createRunRecord(
+    state,
+    ritual,
+    {
+      runKey: 'run-structured',
+      now: () => new Date('2024-06-10T10:00:00.000Z'),
+    },
+  );
+
+  assert.equal(entries.length, 1);
+  const logEntry = entries[0];
+  assert.equal(logEntry.level, 'info');
+  assert.equal(logEntry.entry.event, 'run.created');
+  assert.equal(logEntry.entry.run_id, run.run_key);
+  assert.equal(logEntry.entry.ritual_id, ritual.ritual_key);
+  assert.equal(logEntry.entry.status, 'planned');
+  assert.deepEqual(logEntry.entry.meta, { instant_run: false });
+});
+
+test('instant runs log completion metadata', () => {
+  const { logger, entries } = createCapturingLogger();
+  const state = __testing.createInitialState(logger);
+  const ritual = __testing.createRitualRecord(
+    state,
+    {
+      ritual_key: 'instant-ritual',
+      name: 'Instant Ritual',
+      instant_runs: true,
+      inputs: [],
+    },
+    () => new Date('2024-06-11T09:00:00.000Z'),
+  );
+
+  entries.splice(0, entries.length);
+
+  const run = __testing.createRunRecord(
+    state,
+    ritual,
+    {
+      runKey: 'run-instant',
+      now: () => new Date('2024-06-11T10:00:00.000Z'),
+      completionTime: () => new Date('2024-06-11T10:05:00.000Z'),
+    },
+  );
+
+  assert.equal(run.status, 'complete');
+  assert.equal(entries.length, 1);
+  const logEntry = entries[0];
+  assert.equal(logEntry.entry.event, 'run.created');
+  assert.equal(logEntry.entry.status, 'complete');
+  assert.equal(logEntry.entry.run_id, run.run_key);
+  assert.equal(logEntry.entry.ritual_id, ritual.ritual_key);
+  assert.deepEqual(logEntry.entry.meta, {
+    instant_run: true,
+    completed_immediately: true,
+  });
+});
+
+test('attention lifecycle emits structured log entries with run context', () => {
+  const { logger, entries } = createCapturingLogger();
+  const state = __testing.createInitialState(logger);
+  const ritual = __testing.createRitualRecord(
+    state,
+    {
+      ritual_key: 'attention-ritual',
+      name: 'Attention Ritual',
+      instant_runs: false,
+      inputs: [],
+    },
+    () => new Date('2024-06-12T08:00:00.000Z'),
+  );
+
+  entries.splice(0, entries.length);
+
+  const run = __testing.createRunRecord(
+    state,
+    ritual,
+    {
+      runKey: 'run-attention',
+      now: () => new Date('2024-06-12T09:00:00.000Z'),
+    },
+  );
+
+  entries.splice(0, entries.length);
+
+  const attention = __testing.createAttentionItemRecord(
+    state,
+    run,
+    { type: 'auth_needed', message: 'Re-authenticate the city portal' },
+    () => new Date('2024-06-12T09:30:00.000Z'),
+  );
+
+  assert.equal(entries.length, 1);
+  let logEntry = entries[0];
+  assert.equal(logEntry.entry.event, 'attention.created');
+  assert.equal(logEntry.entry.run_id, run.run_key);
+  assert.equal(logEntry.entry.ritual_id, ritual.ritual_key);
+  assert.equal(logEntry.entry.status, 'planned');
+  assert.deepEqual(logEntry.entry.meta, {
+    attention_id: attention.attention_id,
+    attention_type: 'auth_needed',
+  });
+
+  entries.splice(0, entries.length);
+
+  __testing.resolveAttentionItemRecord(
+    state,
+    attention,
+    () => new Date('2024-06-12T10:00:00.000Z'),
+  );
+
+  assert.equal(entries.length, 1);
+  logEntry = entries[0];
+  assert.equal(logEntry.entry.event, 'attention.resolved');
+  assert.equal(logEntry.entry.run_id, run.run_key);
+  assert.equal(logEntry.entry.ritual_id, ritual.ritual_key);
+  assert.equal(logEntry.entry.status, 'planned');
+  assert.deepEqual(logEntry.entry.meta, {
+    attention_id: attention.attention_id,
+    attention_type: 'auth_needed',
+    resolved_at: '2024-06-12T10:00:00.000Z',
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared logger implementation and wire it through the HTTP server entrypoint
- emit structured run, attention, automation, and invocation log entries with run/ritual context
- cover the new logging contract with focused unit tests and mark the structured logs task complete

## Testing
- npm test
- npm run e2e:smoke

------
https://chatgpt.com/codex/tasks/task_e_68dd6d528d488329b9472526d375f8ab